### PR TITLE
Tweak killing of Tye on Windows

### DIFF
--- a/src/util/process.ts
+++ b/src/util/process.ts
@@ -110,7 +110,7 @@ export class Process extends vscode.Disposable {
                     const tokenListener = token.onCancellationRequested(
                         () => {
                             tokenListener.dispose();
-                            
+
                             if (os.platform() === 'win32') {
                                 // NOTE: Windows does not support SIGTERM/SIGINT/SIGBREAK, so there can be no graceful process shutdown.
                                 //       As a partial mitigation, use `taskkill` to kill the entire process tree.


### PR DESCRIPTION
Windows does not propagate signals (e.g. `SIGTERM`) to processes in the same way as other OSs, so there is no way to shutdown Tye gracefully.  As a mitigation, on Windows, we'll now use `taskkill` rather than the native Node.js `kill()`, to kill processes in a way that also kills sub-processes which helps to take out service processes that would otherwise be left behind and inhibit restarting Tye.

> NOTE: VS Code itself appears to use the same technique when killing processes on Windows.

Related to #26.