### PR TITLE
Use lower-cased workspace folder name when `name` is not defined in tye.yaml

### DIFF
--- a/src/services/tyeApplicationConfiguration.ts
+++ b/src/services/tyeApplicationConfiguration.ts
@@ -6,7 +6,7 @@ import { load } from 'js-yaml';
 import { TextDecoder } from 'util';
 
 export interface TyeApplicationConfiguration {
-    name: string;
+    readonly name: string;
 }
 
 export interface TyeApplicationConfigurationReader {
@@ -46,11 +46,11 @@ export class WorkspaceTyeApplicationConfigurationProvider implements TyeApplicat
                 const content = await vscode.workspace.fs.readFile(file);
                 const contentString = new TextDecoder('utf8').decode(content);
 
-                const configuration = await this.configurationReader.readConfiguration(contentString);
+                let configuration = await this.configurationReader.readConfiguration(contentString);
 
                 if (!configuration.name)
                 {
-                    configuration.name = vscode.workspace.getWorkspaceFolder(file)?.name?.toLowerCase() || '';
+                    configuration = { ...configuration, name: vscode.workspace.getWorkspaceFolder(file)?.name?.toLowerCase() || '' };
                 }
 
                 return configuration;


### PR DESCRIPTION
During scaffolding of the task and the launch configuration, if the property `name` isn't specified, then use the lower-cased workspace folder name as an application name.

Fixes #52 
