### PR TITLE
set activeOnStart to background task tye-run

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 					}
 				],
 				"background": {
+					"activeOnStart": true,
 					"beginsPattern": "^.*Executing application",
 					"endsPattern": "^.*Listening for event pipe events"
 				}


### PR DESCRIPTION
Setting `"activeOnStart": true` to the background task so that the watcher is active when the task starts and the debugger doesn't try to attach the debugger when `tye-run` task is not yet finished(?).
[tasks-appendix](https://code.visualstudio.com/docs/editor/tasks-appendix#:~:text=%2F**%20*%20if%20set%20to%20true%20the%20watcher%20is%20in%20active%20mode%20when%20the%20task%20*%20starts.%20this%20is%20equals%20of%20issuing%20a%20line%20that%20matches%20the%20*%20beginpattern.%20*%2F%20activeonstart%3F%3A%20boolean%3B)

Fixes #59 