### PR TITLE
Enable attaching to Azure Functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -338,6 +338,7 @@
 		"@types/js-yaml": "^4.0.1",
 		"@types/mocha": "^8.2.2",
 		"@types/node": "^14.16.0",
+		"@types/ps-tree": "^1.1.0",
 		"@types/terser-webpack-plugin": "^5.0.3",
 		"@types/vscode": "^1.56.0",
 		"@typescript-eslint/eslint-plugin": "^4.26.0",
@@ -364,6 +365,7 @@
 		"axios": "^0.21.1",
 		"fs-extra": "^10.0.0",
 		"js-yaml": "^4.1.0",
+		"ps-tree": "^1.2.0",
 		"vscode-azureextensionui": "^0.43.7",
 		"vscode-nls": "^5.0.0"
 	}

--- a/src/debug/attachToReplica.ts
+++ b/src/debug/attachToReplica.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { KnownServiceType } from 'src/services/tyeApplicationProvider';
+import { KnownServiceType } from '../services/tyeApplicationProvider';
 import * as psTree from 'ps-tree';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';

--- a/src/debug/attachToReplica.ts
+++ b/src/debug/attachToReplica.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { KnownServiceType } from 'src/services/tyeApplicationProvider';
+import * as psTree from 'ps-tree';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { getLocalizationPathForFile } from '../util/localization';
@@ -8,15 +10,46 @@ import { DebugSessionMonitor } from './debugSessionMonitor';
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
-export async function attachToReplica(debugSessionMonitor: DebugSessionMonitor, folder: vscode.WorkspaceFolder | undefined, replicaName: string, replicaPid: number | undefined): Promise<void> {
+function getProcessTree(pid: number): Promise<readonly psTree.PS[]> {
+    return new Promise(
+        (resolve, reject) => {
+            psTree(
+                pid,
+                (error, children) => {
+                    if (error) {
+                        return reject(error);
+                    }
+
+                    resolve(children);
+                });
+        });
+}
+
+async function getFunctionProcess(pid: number): Promise<string | undefined> {
+    const processes = await getProcessTree(pid);
+
+    const functionProcess = processes.slice().reverse().find(c => /(dotnet|func)(\.exe|)$/i.test(c.COMMAND || ''));
+
+    return functionProcess ? functionProcess.PID : undefined;
+}
+
+export async function attachToReplica(debugSessionMonitor: DebugSessionMonitor, folder: vscode.WorkspaceFolder | undefined, serviceType: KnownServiceType, replicaName: string, replicaPid: number | undefined): Promise<void> {
     if (replicaPid !== undefined && !debugSessionMonitor.isAttached(replicaPid)) {
-        await vscode.debug.startDebugging(
-            folder,
-            {
-                type: 'coreclr',
-                name: localize('debug.attachToReplica.sessionName', 'Tye Replica: {0}', replicaName),
-                request: 'attach',
-                processId: replicaPid.toString()
-            });
+        let actualPid: string | undefined = replicaPid.toString();
+
+        if (serviceType === 'function') {
+            actualPid = await getFunctionProcess(replicaPid);
+        }
+
+        if (actualPid !== undefined) {           
+            await vscode.debug.startDebugging(
+                folder,
+                {
+                    type: 'coreclr',
+                    name: localize('debug.attachToReplica.sessionName', 'Tye Replica: {0}', replicaName),
+                    request: 'attach',
+                    processId: actualPid
+                });
+        }
     }
 }

--- a/src/debug/attachToReplica.ts
+++ b/src/debug/attachToReplica.ts
@@ -30,7 +30,7 @@ async function getFunctionProcess(pid: number): Promise<string | undefined> {
 
     const functionProcess = processes.slice().reverse().find(c => /(dotnet|func)(\.exe|)$/i.test(c.COMMAND || ''));
 
-    return functionProcess ? functionProcess.PID : undefined;
+    return functionProcess ? functionProcess.PID : pid.toString();
 }
 
 export async function attachToReplica(debugSessionMonitor: DebugSessionMonitor, folder: vscode.WorkspaceFolder | undefined, serviceType: KnownServiceType, replicaName: string, replicaPid: number | undefined): Promise<void> {

--- a/src/debug/attachToReplica.ts
+++ b/src/debug/attachToReplica.ts
@@ -4,16 +4,19 @@
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { getLocalizationPathForFile } from '../util/localization';
+import { DebugSessionMonitor } from './debugSessionMonitor';
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
-export async function attachToReplica(folder: vscode.WorkspaceFolder | undefined, replicaName: string, pid: number): Promise<void> {
-    await vscode.debug.startDebugging(
-        folder,
-        {
-            type: 'coreclr',
-            name: localize('debug.attachToReplica.sessionName', 'Tye Replica: {0}', replicaName),
-            request: 'attach',
-            processId: pid.toString()
-        });
+export async function attachToReplica(debugSessionMonitor: DebugSessionMonitor, folder: vscode.WorkspaceFolder | undefined, replicaName: string, replicaPid: number | undefined): Promise<void> {
+    if (replicaPid !== undefined && !debugSessionMonitor.isAttached(replicaPid)) {
+        await vscode.debug.startDebugging(
+            folder,
+            {
+                type: 'coreclr',
+                name: localize('debug.attachToReplica.sessionName', 'Tye Replica: {0}', replicaName),
+                request: 'attach',
+                processId: replicaPid.toString()
+            });
+    }
 }

--- a/src/debug/tyeApplicationWatcher.ts
+++ b/src/debug/tyeApplicationWatcher.ts
@@ -50,9 +50,7 @@ export class TyeApplicationDebugSessionWatcher extends vscode.Disposable impleme
                                         for (const replicaName of Object.keys(service.replicas)) {
                                             const currentPid = service.replicas[replicaName];
 
-                                            if (currentPid !== undefined && !debugSessionMonitor.isAttached(currentPid)) {
-                                                void attachToReplica(watchedApplication.folder, replicaName, currentPid);
-                                            }
+                                            void attachToReplica(debugSessionMonitor, watchedApplication.folder, replicaName, currentPid);
                                         }
                                     }
                                 }

--- a/src/debug/tyeApplicationWatcher.ts
+++ b/src/debug/tyeApplicationWatcher.ts
@@ -50,7 +50,7 @@ export class TyeApplicationDebugSessionWatcher extends vscode.Disposable impleme
                                         for (const replicaName of Object.keys(service.replicas)) {
                                             const currentPid = service.replicas[replicaName];
 
-                                            void attachToReplica(debugSessionMonitor, watchedApplication.folder, replicaName, currentPid);
+                                            void attachToReplica(debugSessionMonitor, watchedApplication.folder, service.serviceType, replicaName, currentPid);
                                         }
                                     }
                                 }

--- a/src/debug/tyeDebugConfigurationProvider.ts
+++ b/src/debug/tyeDebugConfigurationProvider.ts
@@ -56,7 +56,7 @@ export class TyeDebugConfigurationProvider implements vscode.DebugConfigurationP
             for (const replicaName of Object.keys(service.replicas)) {
                 const pid = service.replicas[replicaName];
 
-                await attachToReplica(this.debugSessionMonitor, folder, replicaName, pid);
+                await attachToReplica(this.debugSessionMonitor, folder, service.serviceType, replicaName, pid);
             }
         }
 

--- a/src/debug/tyeDebugConfigurationProvider.ts
+++ b/src/debug/tyeDebugConfigurationProvider.ts
@@ -56,9 +56,7 @@ export class TyeDebugConfigurationProvider implements vscode.DebugConfigurationP
             for (const replicaName of Object.keys(service.replicas)) {
                 const pid = service.replicas[replicaName];
 
-                if (pid !== undefined && !this.debugSessionMonitor.isAttached(pid)) {
-                    await attachToReplica(folder, replicaName, pid);
-                }
+                await attachToReplica(this.debugSessionMonitor, folder, replicaName, pid);
             }
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,9 +109,9 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 						replicas.push(node.replica);
 					}
 
-					for (const replica of replicas.filter(r => r.pid !== undefined && !debugSessionMonitor.isAttached(r.pid))) {
+					for (const replica of replicas) {
 						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-						await attachToReplica(undefined, replica.name, replica.pid!);
+						await attachToReplica(debugSessionMonitor, undefined, replica.name, replica.pid!);
 					}
 				});
 
@@ -162,9 +162,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 								for (const replicaName of Object.keys(service.replicas)) {
 									const pid = service.replicas[replicaName];
 
-									if (pid !== undefined && !debugSessionMonitor.isAttached(pid)) {
-										await attachToReplica(undefined, replicaName, pid);
-									}
+									await attachToReplica(debugSessionMonitor, undefined, replicaName, pid);
 								}
 						}
 					}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,6 @@ import VsCodeSettingsProvider from './services/settingsProvider';
 import LocalTyePathProvider from './services/tyePathProvider';
 import createBrowseServiceCommand from './commands/browseService';
 import TreeNode from './views/treeNode';
-import { names } from './util/generators';
 
 export function activate(context: vscode.ExtensionContext): Promise<void> {
 	function registerDisposable<T extends vscode.Disposable>(disposable: T): T {
@@ -111,8 +110,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 					}
 
 					for (const replica of replicas) {
-						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-						await attachToReplica(debugSessionMonitor, undefined, replica.serviceType, replica.replica.name, replica.replica.pid!);
+						await attachToReplica(debugSessionMonitor, undefined, replica.serviceType, replica.replica.name, replica.replica.pid);
 					}
 				});
 

--- a/src/services/tyeApplicationProvider.ts
+++ b/src/services/tyeApplicationProvider.ts
@@ -7,7 +7,7 @@ import { first, switchMap } from 'rxjs/operators';
 import { MonitoredTask, TaskMonitor } from '../tasks/taskMonitor';
 import { TyeClientProvider } from './tyeClient';
 
-type KnownServiceType = 'project' | 'function';
+export type KnownServiceType = 'project' | 'function';
 
 export type TyeProjectService = {
     replicas: { [key: string]: number | undefined };

--- a/src/services/tyeApplicationProvider.ts
+++ b/src/services/tyeApplicationProvider.ts
@@ -7,8 +7,11 @@ import { first, switchMap } from 'rxjs/operators';
 import { MonitoredTask, TaskMonitor } from '../tasks/taskMonitor';
 import { TyeClientProvider } from './tyeClient';
 
+type KnownServiceType = 'project' | 'function';
+
 export type TyeProjectService = {
     replicas: { [key: string]: number | undefined };
+    serviceType: KnownServiceType;
 };
 
 export type TyeApplication = {
@@ -68,7 +71,7 @@ export class TaskBasedTyeApplicationProvider implements TyeApplicationProvider {
             const services = await tyeClient.getServices();
             const projectServices =
                 (services ?? [])
-                    .filter(service => service.serviceType === 'project')
+                    .filter(service => (service.serviceType === 'project') || (service.serviceType === 'function'))
                     .reduce<{ [key: string]: TyeProjectService }>(
                         (serviceMap, service) => {
                             serviceMap[service.description.name] = {
@@ -79,7 +82,8 @@ export class TaskBasedTyeApplicationProvider implements TyeApplicationProvider {
                                                 replicaMap[replicaName] = service.replicas[replicaName].pid;
                                                 return replicaMap;
                                             },
-                                            {})
+                                            {}),
+                                serviceType: <KnownServiceType>service.serviceType
                             };
                             return serviceMap;
                         },

--- a/src/views/services/tyeReplicaNode.ts
+++ b/src/views/services/tyeReplicaNode.ts
@@ -37,7 +37,7 @@ export function getReplicaBrowseUrl(service: TyeService, replica: TyeReplica): s
 }
 
 export function isAttachable(service: TyeService): boolean {
-    return service.serviceType === 'project';
+    return (service.serviceType === 'project') || (service.serviceType === 'function');
 }
 
 export default class TyeReplicaNode implements TyeNode {

--- a/yarn.lock
+++ b/yarn.lock
@@ -340,6 +340,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.1.tgz#5e07e0cb2ff793aa7a1b41deae76221e6166049f"
   integrity sha512-/tpUyFD7meeooTRwl3sYlihx2BrJE7q9XF71EguPFIySj9B7qgnRtHsHTho+0AUm4m1SvWGm6uSncrR94q6Vtw==
 
+"@types/ps-tree@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/ps-tree/-/ps-tree-1.1.0.tgz#7e2034e8ccdc16f6b0ced7a88529ebcb3b1dc424"
+  integrity sha512-rm5GU5sefQpg2d/DQ+fMDZnl9aPiJjJ9FYA12isIocNTZqu9VDZRgCRBx3oYFEdmDpmPmY4hxxmY/+1a84Rtzg==
+
 "@types/terser-webpack-plugin@^5.0.3":
   version "5.0.3"
   resolved "https://registry.npmjs.org/@types/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz"
@@ -2150,6 +2155,19 @@ event-emitter@^0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+event-stream@=3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 event-stream@^3.3.4:
   version "3.3.5"
   resolved "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz"
@@ -2483,7 +2501,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-from@^0.1.7:
+from@^0.1.7, from@~0:
   version "0.1.7"
   resolved "https://registry.npmjs.org/from/-/from-0.1.7.tgz"
   integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
@@ -3571,6 +3589,11 @@ map-stream@0.0.7:
   resolved "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz"
   integrity sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=
 
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+  integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
+
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz"
@@ -4210,7 +4233,7 @@ path-type@^4.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pause-stream@^0.0.11:
+pause-stream@0.0.11, pause-stream@^0.0.11:
   version "0.0.11"
   resolved "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
   integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
@@ -4292,6 +4315,13 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+ps-tree@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.2.0.tgz#5e7425b89508736cdd4f2224d028f7bb3f722ebd"
+  integrity sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==
+  dependencies:
+    event-stream "=3.3.4"
 
 psl@^1.1.28:
   version "1.8.0"
@@ -4854,6 +4884,13 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  dependencies:
+    through "2"
+
 split@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/split/-/split-1.0.1.tgz"
@@ -4891,6 +4928,13 @@ stream-combiner@^0.2.2:
   dependencies:
     duplexer "~0.1.1"
     through "~2.3.4"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  integrity sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=
+  dependencies:
+    duplexer "~0.1.1"
 
 stream-exhaust@^1.0.1:
   version "1.0.2"
@@ -5153,7 +5197,7 @@ through2@^3.0.1:
     inherits "^2.0.4"
     readable-stream "2 || 3"
 
-through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.4:
+through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=


### PR DESCRIPTION
Azure Functions are considered a separate service type in Tye, which is currently being ignored for attaching purposes.  The logic for monitoring and attaching to service replica processes has been updated to include function-type services, borrowing logic from [vscode-azurefunctions](https://github.com/microsoft/vscode-azurefunctions) for identifying the "real" process ID for a given function.

Resolves #89 