### PR TITLE
Handle Ctrl+C in task (pseudo) terminal windows

### DIFF
--- a/src/tasks/taskPseudoterminal.ts
+++ b/src/tasks/taskPseudoterminal.ts
@@ -40,6 +40,13 @@ export default class TaskPseudoterminal extends vscode.Disposable implements vsc
         this.closeWithValue();
     }
 
+    handleInput?(data: string): void {
+        // If the user presses Ctrl + C in the terminal window, close it.
+        if (data === '\u0003') {
+            this.close();
+        }
+    }
+
     private closeWithValue(value: number | void): void {
         this.cts.cancel();
         this.closeEmitter.fire(value);

--- a/src/tasks/taskPseudoterminal.ts
+++ b/src/tasks/taskPseudoterminal.ts
@@ -6,6 +6,10 @@ import TaskPseudoterminalWriter, { PseudoterminalWriter } from './taskPseudoterm
 
 export type TaskPseudoterminalCallback = (writer: PseudoterminalWriter, cts: vscode.CancellationToken) => Promise<number | void>;
 
+const ControlCodes = {
+    CtrlC: '\u0003'
+};
+
 export default class TaskPseudoterminal extends vscode.Disposable implements vscode.Pseudoterminal {
     private readonly closeEmitter: vscode.EventEmitter<number | void> = new vscode.EventEmitter<number | void>();
     private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
@@ -41,8 +45,8 @@ export default class TaskPseudoterminal extends vscode.Disposable implements vsc
     }
 
     handleInput?(data: string): void {
-        // If the user presses Ctrl + C in the terminal window, close it.
-        if (data === '\u0003') {
+        // If the user presses Ctrl + C in the terminal window, close it...
+        if (data.includes(ControlCodes.CtrlC)) {
             this.close();
         }
     }


### PR DESCRIPTION
When running `tye run` in a VS Code terminal window, it's natural to use `Ctrl+C` to stop Tye from running.  When running a `tye-run`, the output is shown in a (pseudo) terminal window in much the same way but, currently, the only way to stop the task is to explicitly invoke the terminal "close" command.  This feels inconsistent with the way users tend to want to stop Tye in the same way.

This change traps input to the pseudo terminal window and stops the Tye instance when the user presses `Ctrl+C`.

> Note that no other input is handled.

Resolves #60 