### PR TITLE
Add Tye version detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"url": "https://github.com/Microsoft/vscode-tye/"
 	},
 	"engines": {
-		"tye": ">=0.9",
+		"tye": ">=0.7.0-alpha.21279.2",
 		"vscode": "^1.56.2"
 	},
 	"categories": [

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
 		"onCommand:vscode-tye.commands.scaffolding.initTye",
 		"onCommand:vscode-tye.commands.scaffolding.scaffoldTyeTasks",
 		"onCommand:vscode-tye.commands.showLogs",
-		"onCommand:vscode-tye.help.getStarted",
-		"onCommand:vscode-tye.help.readDocumentation",
-		"onCommand:vscode-tye.help.reportIssue",
-		"onCommand:vscode-tye.help.reviewIssues",
+		"onCommand:vscode-tye.commands.help.getStarted",
+		"onCommand:vscode-tye.commands.help.installTye",
+		"onCommand:vscode-tye.commands.help.readDocumentation",
+		"onCommand:vscode-tye.commands.help.reportIssue",
+		"onCommand:vscode-tye.commands.help.reviewIssues",
 		"onCommand:workbench.action.tasks.runTask",
 		"onDebugResolve:tye",
 		"onView:vscode-tye.views.help",
@@ -244,23 +245,28 @@
 				"icon": "$(output)"
 			},
 			{
-				"command": "vscode-tye.help.getStarted",
-				"title": "%vscode-tye.help.getStarted.title%",
+				"command": "vscode-tye.commands.help.getStarted",
+				"title": "%vscode-tye.commands.help.getStarted.title%",
 				"category": "Tye"
 			},
 			{
-				"command": "vscode-tye.help.readDocumentation",
-				"title": "%vscode-tye.help.readDocumentation.title%",
+				"command": "vscode-tye.commands.help.installTye",
+				"title": "%vscode-tye.commands.help.installTye.title%",
 				"category": "Tye"
 			},
 			{
-				"command": "vscode-tye.help.reportIssue",
-				"title": "%vscode-tye.help.reportIssue.title%",
+				"command": "vscode-tye.commands.help.readDocumentation",
+				"title": "%vscode-tye.commands.help.readDocumentation.title%",
 				"category": "Tye"
 			},
 			{
-				"command": "vscode-tye.help.reviewIssues",
-				"title": "%vscode-tye.help.reviewIssues.title%",
+				"command": "vscode-tye.commands.help.reportIssue",
+				"title": "%vscode-tye.commands.help.reportIssue.title%",
+				"category": "Tye"
+			},
+			{
+				"command": "vscode-tye.commands.help.reviewIssues",
+				"title": "%vscode-tye.commands.help.reviewIssues.title%",
 				"category": "Tye"
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -172,7 +172,13 @@
 		"viewsWelcome": [
 			{
 				"view": "vscode-tye.views.services",
-				"contents": "%vscode-tye.views.services.contents%"
+				"contents": "%vscode-tye.views.services.contents.notInstalled%",
+				"when": "vscode-tye.views.services.state == 'notInstalled'"
+			},
+			{
+				"view": "vscode-tye.views.services",
+				"contents": "%vscode-tye.views.services.contents.notRunning%",
+				"when": "vscode-tye.views.services.state == 'notRunning'"
 			}
 		],
 		"viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"url": "https://github.com/Microsoft/vscode-tye/"
 	},
 	"engines": {
+		"tye": ">=0.9",
 		"vscode": "^1.56.2"
 	},
 	"categories": [

--- a/package.json
+++ b/package.json
@@ -348,6 +348,7 @@
 		"@types/mocha": "^8.2.2",
 		"@types/node": "^14.16.0",
 		"@types/ps-tree": "^1.1.0",
+		"@types/semver": "^7.3.6",
 		"@types/terser-webpack-plugin": "^5.0.3",
 		"@types/vscode": "^1.56.0",
 		"@typescript-eslint/eslint-plugin": "^4.26.0",
@@ -375,6 +376,7 @@
 		"fs-extra": "^10.0.0",
 		"js-yaml": "^4.1.0",
 		"ps-tree": "^1.2.0",
+		"semver": "^7.3.5",
 		"vscode-azureextensionui": "^0.43.7",
 		"vscode-nls": "^5.0.0"
 	}

--- a/package.nls.json
+++ b/package.nls.json
@@ -35,6 +35,7 @@
     "vscode-tye.tasks.tye-run.properties.watch.description": "Watches for code changes for all projects.",
 
     "vscode-tye.views.help.name": "Help and Feedback",
-    "vscode-tye.views.services.contents": "The extension requires you to run Tye in a command window. This extension will attempt to access `http://localhost:8000/api/v1/services` by default.",
+    "vscode-tye.views.services.contents.notInstalled": "The extension requires you to install Tye.",
+    "vscode-tye.views.services.contents.notRunning": "The extension requires you to run Tye in a command window. This extension will attempt to access `http://localhost:8000/api/v1/services` by default.",
     "vscode-tye.views.services.name": "Tye Services"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,10 +8,11 @@
     "vscode-tye.commands.scaffolding.initTye.title": "Initialize Tye",
     "vscode-tye.commands.scaffolding.scaffoldTyeTasks.title": "Scaffold Tye Tasks",
     "vscode-tye.commands.showLogs.title": "Logs",
-    "vscode-tye.help.readDocumentation.title": "Read Documentation",
-    "vscode-tye.help.getStarted.title": "Get Started",
-    "vscode-tye.help.reportIssue.title": "Report Issue",
-    "vscode-tye.help.reviewIssues.title": "Review Issues",
+    "vscode-tye.commands.help.getStarted.title": "Get Started",
+    "vscode-tye.commands.help.installTye.title": "Install Tye",
+    "vscode-tye.commands.help.readDocumentation.title": "Read Documentation",
+    "vscode-tye.commands.help.reportIssue.title": "Report Issue",
+    "vscode-tye.commands.help.reviewIssues.title": "Review Issues",
 
     "vscode-tye.configuration.paths.tyePath.description": "The full path to the Tye binary.",
 
@@ -35,7 +36,7 @@
     "vscode-tye.tasks.tye-run.properties.watch.description": "Watches for code changes for all projects.",
 
     "vscode-tye.views.help.name": "Help and Feedback",
-    "vscode-tye.views.services.contents.notInstalled": "The extension requires you to install Tye.",
+    "vscode-tye.views.services.contents.notInstalled": "The extension requires you to install Tye.\n[Install Tye](command:vscode-tye.commands.help.installTye)",
     "vscode-tye.views.services.contents.notRunning": "The extension requires you to run Tye in a command window. This extension will attempt to access `http://localhost:8000/api/v1/services` by default.",
     "vscode-tye.views.services.name": "Tye Services"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -36,7 +36,7 @@
     "vscode-tye.tasks.tye-run.properties.watch.description": "Watches for code changes for all projects.",
 
     "vscode-tye.views.help.name": "Help and Feedback",
-    "vscode-tye.views.services.contents.notInstalled": "The extension requires you to install Tye.\n[Install Tye](command:vscode-tye.commands.help.installTye)",
+    "vscode-tye.views.services.contents.notInstalled": "A compatible version of Tye has not been found. You may need to install a more recent version.\n[Install Latest Tye](command:vscode-tye.commands.help.installTye)",
     "vscode-tye.views.services.contents.notRunning": "The extension requires you to run Tye in a command window. This extension will attempt to access `http://localhost:8000/api/v1/services` by default.",
     "vscode-tye.views.services.name": "Tye Services"
 }

--- a/src/commands/help/installTye.ts
+++ b/src/commands/help/installTye.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { UserInput } from '../../services/userInput';
+
+export function installTye(ui: UserInput): Thenable<boolean> {
+    return ui.openExternal('https://aka.ms/vscode-tye-help-install-tye');
+}
+
+const createInstallTyeCommand = (ui: UserInput) => (): Thenable<boolean> => installTye(ui);
+
+export default createInstallTyeCommand;

--- a/src/commands/scaffolding/initializeTye.ts
+++ b/src/commands/scaffolding/initializeTye.ts
@@ -39,7 +39,7 @@ export async function initializeTye(
     // TODO: Support multiple folders.
     const folder = folders[0];
 
-    await tyeInstallationManager.ensureInstalledVersion('>=0.9', context.errorHandling);
+    await tyeInstallationManager.ensureInstalled(context.errorHandling);
 
     // TODO: Add conflict resolution.
     await tyeCliClient.init({ force: true, path: folder.uri.fsPath });

--- a/src/commands/scaffolding/initializeTye.ts
+++ b/src/commands/scaffolding/initializeTye.ts
@@ -7,7 +7,7 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { getLocalizationPathForFile } from '../../util/localization';
 import { TyeCliClient } from '../../services/tyeCliClient';
 import { TyeApplicationConfigurationProvider } from '../../services/tyeApplicationConfiguration';
-import { TyeInstallationManager } from 'src/services/tyeInstallationManager';
+import { TyeInstallationManager } from '../../services/tyeInstallationManager';
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 

--- a/src/commands/scaffolding/initializeTye.ts
+++ b/src/commands/scaffolding/initializeTye.ts
@@ -7,6 +7,7 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { getLocalizationPathForFile } from '../../util/localization';
 import { TyeCliClient } from '../../services/tyeCliClient';
 import { TyeApplicationConfigurationProvider } from '../../services/tyeApplicationConfiguration';
+import { TyeInstallationManager } from 'src/services/tyeInstallationManager';
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
@@ -25,7 +26,8 @@ export async function initializeTye(
     folderProvider: () => (readonly vscode.WorkspaceFolder[] | undefined),
     openProvider: (uri: vscode.Uri) => Promise<void>,
     tyeApplicationConfigurationProvider: TyeApplicationConfigurationProvider,
-    tyeCliClient: TyeCliClient): Promise<void> {
+    tyeCliClient: TyeCliClient,
+    tyeInstallationManager: TyeInstallationManager): Promise<void> {
     const folders = folderProvider();
 
     if (!folders || folders.length === 0) {
@@ -36,6 +38,8 @@ export async function initializeTye(
 
     // TODO: Support multiple folders.
     const folder = folders[0];
+
+    await tyeInstallationManager.ensureInstalledVersion('>=0.9');
 
     // TODO: Add conflict resolution.
     await tyeCliClient.init({ force: true, path: folder.uri.fsPath });
@@ -48,6 +52,6 @@ export async function initializeTye(
     }
 }
 
-const createInitializeTyeCommand = (tyeApplicationConfigurationProvider: TyeApplicationConfigurationProvider, tyeCliClient: TyeCliClient) => (context: IActionContext): Promise<void> => initializeTye(context, folderProvider, openProvider, tyeApplicationConfigurationProvider, tyeCliClient);
+const createInitializeTyeCommand = (tyeApplicationConfigurationProvider: TyeApplicationConfigurationProvider, tyeCliClient: TyeCliClient, tyeInstallationManager: TyeInstallationManager) => (context: IActionContext): Promise<void> => initializeTye(context, folderProvider, openProvider, tyeApplicationConfigurationProvider, tyeCliClient, tyeInstallationManager);
 
 export default createInitializeTyeCommand;

--- a/src/commands/scaffolding/initializeTye.ts
+++ b/src/commands/scaffolding/initializeTye.ts
@@ -39,7 +39,7 @@ export async function initializeTye(
     // TODO: Support multiple folders.
     const folder = folders[0];
 
-    await tyeInstallationManager.ensureInstalledVersion('>=0.9');
+    await tyeInstallationManager.ensureInstalledVersion('>=0.9', context.errorHandling);
 
     // TODO: Add conflict resolution.
     await tyeCliClient.init({ force: true, path: folder.uri.fsPath });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,12 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 
 			registerDisposable(vscode.workspace.registerTextDocumentContentProvider('tye-log', new TyeLogsContentProvider(tyeClientProvider)));
 		
-			const treeProvider = new TyeServicesTreeDataProvider(tyeApplicationProvider, tyeClientProvider);
+			const extensionPackage = <ExtensionPackage>context.extension.packageJSON;
+			const tyeCliClient = new LocalTyeCliClient(() => tyePathProvider.getTyePath());
+			const ui = new AggregateUserInput(ext.ui);
+			const tyeInstallationManager = new LocalTyeInstallationManager(extensionPackage.engines['tye'], tyeCliClient, ui);
+
+			const treeProvider = new TyeServicesTreeDataProvider(tyeApplicationProvider, tyeClientProvider, tyeInstallationManager);
 
 			registerDisposable(vscode.window.registerTreeDataProvider(
 				'vscode-tye.views.services',
@@ -86,8 +91,6 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 				() => {
 					treeProvider.refresh();
 				});
-
-			const ui = new AggregateUserInput(ext.ui);
 
 			telemetryProvider.registerCommandWithTelemetry(
 				'vscode-tye.commands.browseService',
@@ -123,10 +126,6 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			const settingsProvider = new VsCodeSettingsProvider();
 			const tyePathProvider = new LocalTyePathProvider(settingsProvider);
 			const tyeApplicationConfigurationProvider = new WorkspaceTyeApplicationConfigurationProvider(new YamlTyeApplicationConfigurationReader());
-
-			const extensionPackage = <ExtensionPackage>context.extension.packageJSON;
-			const tyeCliClient = new LocalTyeCliClient(() => tyePathProvider.getTyePath());
-			const tyeInstallationManager = new LocalTyeInstallationManager(extensionPackage.engines['tye'], tyeCliClient, ui);
 
 			telemetryProvider.registerCommandWithTelemetry(
 				'vscode-tye.commands.scaffolding.initTye',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,7 +121,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			const tyeApplicationConfigurationProvider = new WorkspaceTyeApplicationConfigurationProvider(new YamlTyeApplicationConfigurationReader());
 
 			const tyeCliClient = new LocalTyeCliClient(() => tyePathProvider.getTyePath());
-			const tyeInstallationManager = new LocalTyeInstallationManager(tyeCliClient);
+			const tyeInstallationManager = new LocalTyeInstallationManager(tyeCliClient, ui);
 
 			telemetryProvider.registerCommandWithTelemetry(
 				'vscode-tye.commands.scaffolding.initTye',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,7 +185,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 		
 			registerDisposable(vscode.debug.registerDebugConfigurationProvider('tye', new TyeDebugConfigurationProvider(debugSessionMonitor, tyeApplicationProvider, applicationWatcher)));
 		
-			registerDisposable(vscode.tasks.registerTaskProvider('tye-run', new TyeRunCommandTaskProvider(taskMonitor, telemetryProvider, tyePathProvider, tyeClientProvider, tyeApplicationProvider)));
+			registerDisposable(vscode.tasks.registerTaskProvider('tye-run', new TyeRunCommandTaskProvider(taskMonitor, telemetryProvider, tyeApplicationProvider, tyeClientProvider, tyeInstallationManager, tyePathProvider)));
 
 			return Promise.resolve();
 		});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,10 @@ import createBrowseServiceCommand from './commands/browseService';
 import TreeNode from './views/treeNode';
 import LocalTyeInstallationManager from './services/tyeInstallationManager';
 
+interface ExtensionPackage {
+	engines: { [key: string]: string };
+}
+
 export function activate(context: vscode.ExtensionContext): Promise<void> {
 	function registerDisposable<T extends vscode.Disposable>(disposable: T): T {
 		context.subscriptions.push(disposable);
@@ -120,8 +124,9 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			const tyePathProvider = new LocalTyePathProvider(settingsProvider);
 			const tyeApplicationConfigurationProvider = new WorkspaceTyeApplicationConfigurationProvider(new YamlTyeApplicationConfigurationReader());
 
+			const extensionPackage = <ExtensionPackage>context.extension.packageJSON;
 			const tyeCliClient = new LocalTyeCliClient(() => tyePathProvider.getTyePath());
-			const tyeInstallationManager = new LocalTyeInstallationManager(tyeCliClient, ui);
+			const tyeInstallationManager = new LocalTyeInstallationManager(extensionPackage.engines['tye'], tyeCliClient, ui);
 
 			telemetryProvider.registerCommandWithTelemetry(
 				'vscode-tye.commands.scaffolding.initTye',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import LocalTyePathProvider from './services/tyePathProvider';
 import createBrowseServiceCommand from './commands/browseService';
 import TreeNode from './views/treeNode';
 import LocalTyeInstallationManager from './services/tyeInstallationManager';
+import createInstallTyeCommand from './commands/help/installTye';
 
 interface ExtensionPackage {
 	engines: { [key: string]: string };
@@ -175,10 +176,11 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 					}
 				});
 		
-			telemetryProvider.registerCommandWithTelemetry('vscode-tye.help.readDocumentation', createReadDocumentationCommand(ui));
-			telemetryProvider.registerCommandWithTelemetry('vscode-tye.help.getStarted', createGetStartedCommand(ui));
-			telemetryProvider.registerCommandWithTelemetry('vscode-tye.help.reportIssue', createReportIssueCommand(ui));
-			telemetryProvider.registerCommandWithTelemetry('vscode-tye.help.reviewIssues', createReviewIssuesCommand(ui));
+			telemetryProvider.registerCommandWithTelemetry('vscode-tye.commands.help.getStarted', createGetStartedCommand(ui));
+			telemetryProvider.registerCommandWithTelemetry('vscode-tye.commands.help.installTye', createInstallTyeCommand(ui));
+			telemetryProvider.registerCommandWithTelemetry('vscode-tye.commands.help.readDocumentation', createReadDocumentationCommand(ui));
+			telemetryProvider.registerCommandWithTelemetry('vscode-tye.commands.help.reportIssue', createReportIssueCommand(ui));
+			telemetryProvider.registerCommandWithTelemetry('vscode-tye.commands.help.reviewIssues', createReviewIssuesCommand(ui));
 	
 			const applicationWatcher = registerDisposable(new TyeApplicationDebugSessionWatcher(debugSessionMonitor, tyeApplicationProvider));
 		

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,7 +75,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			const ui = new AggregateUserInput(ext.ui);
 			const tyeInstallationManager = new LocalTyeInstallationManager(extensionPackage.engines['tye'], tyeCliClient, ui);
 
-			const treeProvider = new TyeServicesTreeDataProvider(tyeApplicationProvider, tyeClientProvider, tyeInstallationManager);
+			const treeProvider = new TyeServicesTreeDataProvider(tyeApplicationProvider, tyeClientProvider, tyeInstallationManager, ui);
 
 			registerDisposable(vscode.window.registerTreeDataProvider(
 				'vscode-tye.views.services',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ import VsCodeSettingsProvider from './services/settingsProvider';
 import LocalTyePathProvider from './services/tyePathProvider';
 import createBrowseServiceCommand from './commands/browseService';
 import TreeNode from './views/treeNode';
+import LocalTyeInstallationManager from './services/tyeInstallationManager';
 
 export function activate(context: vscode.ExtensionContext): Promise<void> {
 	function registerDisposable<T extends vscode.Disposable>(disposable: T): T {
@@ -119,9 +120,12 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			const tyePathProvider = new LocalTyePathProvider(settingsProvider);
 			const tyeApplicationConfigurationProvider = new WorkspaceTyeApplicationConfigurationProvider(new YamlTyeApplicationConfigurationReader());
 
+			const tyeCliClient = new LocalTyeCliClient(() => tyePathProvider.getTyePath());
+			const tyeInstallationManager = new LocalTyeInstallationManager(tyeCliClient);
+
 			telemetryProvider.registerCommandWithTelemetry(
 				'vscode-tye.commands.scaffolding.initTye',
-				createInitializeTyeCommand(tyeApplicationConfigurationProvider, new LocalTyeCliClient(tyePathProvider)));
+				createInitializeTyeCommand(tyeApplicationConfigurationProvider, tyeCliClient, tyeInstallationManager));
 
 			telemetryProvider.registerCommandWithTelemetry(
 				'vscode-tye.commands.scaffolding.scaffoldTyeTasks',

--- a/src/services/tyeInstallationManager.ts
+++ b/src/services/tyeInstallationManager.ts
@@ -8,12 +8,17 @@ import { UserInput } from './userInput';
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
 export interface TyeInstallationManager {
+    ensureInstalled(context?: IErrorHandlingContext): Promise<void>;
     ensureInstalledVersion(version: string, context?: IErrorHandlingContext): Promise<void>;
     isVersionInstalled(version: string): Promise<boolean>;
 }
 
 export default class LocalTyeInstallationManager implements TyeInstallationManager {
-    constructor(private readonly tyeCliClient: TyeCliClient, private readonly ui: UserInput) {
+    constructor(private readonly expectedVersion: string, private readonly tyeCliClient: TyeCliClient, private readonly ui: UserInput) {
+    }
+
+    ensureInstalled(context?: IErrorHandlingContext): Promise<void> {
+        return this.ensureInstalledVersion(this.expectedVersion, context);
     }
 
     async ensureInstalledVersion(version: string, context?: IErrorHandlingContext): Promise<void> {
@@ -26,15 +31,14 @@ export default class LocalTyeInstallationManager implements TyeInstallationManag
                         callback: async () => {
                             await this.ui.openExternal('https://aka.ms/vscode-tye-help-install-tye')
                         },
-                        title: 'Install Tye'
+                        title: localize('services.tyeInstallationManager.installLatestTitle', 'Install Latest')
                     }
                 ];
 
                 context.suppressReportIssue = true;
             }
 
-            // TODO: Use UI to show rich error.
-            throw new Error(localize('services.tyeInstallationManager.versionNotInstalled', 'A required version of Tye has not been installed. Install a more recent version.'));
+            throw new Error(localize('services.tyeInstallationManager.versionNotInstalled', 'A compatible version of Tye has not been found. You may need to install a more recent version.'));
         }
     }
 

--- a/src/services/tyeInstallationManager.ts
+++ b/src/services/tyeInstallationManager.ts
@@ -46,7 +46,7 @@ export default class LocalTyeInstallationManager implements TyeInstallationManag
         try {
             const cliVersion = await this.tyeCliClient.version();
             
-            return semver.satisfies(cliVersion, version);
+            return semver.satisfies(cliVersion, version, { includePrerelease: true });
         }
         catch {
             return false;

--- a/src/services/tyeInstallationManager.ts
+++ b/src/services/tyeInstallationManager.ts
@@ -10,6 +10,8 @@ const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 export interface TyeInstallationManager {
     ensureInstalled(context?: IErrorHandlingContext): Promise<void>;
     ensureInstalledVersion(version: string, context?: IErrorHandlingContext): Promise<void>;
+    
+    isInstalled(): Promise<boolean>;
     isVersionInstalled(version: string): Promise<boolean>;
 }
 
@@ -40,6 +42,10 @@ export default class LocalTyeInstallationManager implements TyeInstallationManag
 
             throw new Error(localize('services.tyeInstallationManager.versionNotInstalled', 'A compatible version of Tye has not been found. You may need to install a more recent version.'));
         }
+    }
+
+    isInstalled(): Promise<boolean> {
+        return this.isVersionInstalled(this.expectedVersion);
     }
 
     async isVersionInstalled(version: string): Promise<boolean> {      

--- a/src/services/tyeInstallationManager.ts
+++ b/src/services/tyeInstallationManager.ts
@@ -2,30 +2,50 @@ import * as semver from 'semver';
 import { TyeCliClient } from './tyeCliClient';
 import * as nls from 'vscode-nls';
 import { getLocalizationPathForFile } from '../util/localization';
+import { IErrorHandlingContext } from 'vscode-azureextensionui';
+import { UserInput } from './userInput';
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
 export interface TyeInstallationManager {
-    ensureInstalledVersion(version: string): Promise<void>;
+    ensureInstalledVersion(version: string, context?: IErrorHandlingContext): Promise<void>;
     isVersionInstalled(version: string): Promise<boolean>;
 }
 
 export default class LocalTyeInstallationManager implements TyeInstallationManager {
-    constructor(private readonly tyeCliClient: TyeCliClient) {
+    constructor(private readonly tyeCliClient: TyeCliClient, private readonly ui: UserInput) {
     }
 
-    async ensureInstalledVersion(version: string): Promise<void> {
+    async ensureInstalledVersion(version: string, context?: IErrorHandlingContext): Promise<void> {
         const isVersionInstalled = await this.isVersionInstalled(version);
 
         if (!isVersionInstalled) {
+            if (context) {
+                context.buttons = [
+                    {
+                        callback: async () => {
+                            await this.ui.openExternal('https://aka.ms/vscode-tye-help-install-tye')
+                        },
+                        title: 'Install Tye'
+                    }
+                ];
+
+                context.suppressReportIssue = true;
+            }
+
             // TODO: Use UI to show rich error.
             throw new Error(localize('services.tyeInstallationManager.versionNotInstalled', 'A required version of Tye has not been installed. Install a more recent version.'));
         }
     }
 
-    async isVersionInstalled(version: string): Promise<boolean> {
-        const cliVersion = await this.tyeCliClient.version();
-
-        return semver.satisfies(cliVersion, version);
+    async isVersionInstalled(version: string): Promise<boolean> {      
+        try {
+            const cliVersion = await this.tyeCliClient.version();
+            
+            return semver.satisfies(cliVersion, version);
+        }
+        catch {
+            return false;
+        }
     }
 }

--- a/src/services/tyeInstallationManager.ts
+++ b/src/services/tyeInstallationManager.ts
@@ -19,6 +19,8 @@ export interface TyeInstallationManager {
 }
 
 export default class LocalTyeInstallationManager implements TyeInstallationManager {
+    private readonly satisfiedVersions = new Set<string>();
+
     constructor(private readonly expectedVersion: string, private readonly tyeCliClient: TyeCliClient, private readonly ui: UserInput) {
     }
 
@@ -52,13 +54,23 @@ export default class LocalTyeInstallationManager implements TyeInstallationManag
     }
 
     async isVersionInstalled(version: string): Promise<boolean> {      
+        if (this.satisfiedVersions.has(version)) {
+            return true;
+        }
+
         try {
             const cliVersion = await this.tyeCliClient.version();
             
-            return semver.satisfies(cliVersion, version, { includePrerelease: true });
+            if (semver.satisfies(cliVersion, version, { includePrerelease: true })) {
+                this.satisfiedVersions.add(version);
+
+                return true;
+            }
         }
         catch {
-            return false;
+            // No-op.
         }
+        
+        return false;
     }
 }

--- a/src/services/tyeInstallationManager.ts
+++ b/src/services/tyeInstallationManager.ts
@@ -31,9 +31,9 @@ export default class LocalTyeInstallationManager implements TyeInstallationManag
                 context.buttons = [
                     {
                         callback: async () => {
-                            await this.ui.openExternal('https://aka.ms/vscode-tye-help-install-tye')
+                            await this.ui.executeCommand('vscode-tye.commands.help.installTye')
                         },
-                        title: localize('services.tyeInstallationManager.installLatestTitle', 'Install Latest')
+                        title: localize('services.tyeInstallationManager.installLatestTitle', 'Install Latest Tye')
                     }
                 ];
 

--- a/src/services/tyeInstallationManager.ts
+++ b/src/services/tyeInstallationManager.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as semver from 'semver';
 import { TyeCliClient } from './tyeCliClient';
 import * as nls from 'vscode-nls';

--- a/src/services/tyeInstallationManager.ts
+++ b/src/services/tyeInstallationManager.ts
@@ -1,0 +1,31 @@
+import * as semver from 'semver';
+import { TyeCliClient } from './tyeCliClient';
+import * as nls from 'vscode-nls';
+import { getLocalizationPathForFile } from '../util/localization';
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+export interface TyeInstallationManager {
+    ensureInstalledVersion(version: string): Promise<void>;
+    isVersionInstalled(version: string): Promise<boolean>;
+}
+
+export default class LocalTyeInstallationManager implements TyeInstallationManager {
+    constructor(private readonly tyeCliClient: TyeCliClient) {
+    }
+
+    async ensureInstalledVersion(version: string): Promise<void> {
+        const isVersionInstalled = await this.isVersionInstalled(version);
+
+        if (!isVersionInstalled) {
+            // TODO: Use UI to show rich error.
+            throw new Error(localize('services.tyeInstallationManager.versionNotInstalled', 'A required version of Tye has not been installed. Install a more recent version.'));
+        }
+    }
+
+    async isVersionInstalled(version: string): Promise<boolean> {
+        const cliVersion = await this.tyeCliClient.version();
+
+        return semver.satisfies(cliVersion, version);
+    }
+}

--- a/src/services/tyePathProvider.ts
+++ b/src/services/tyePathProvider.ts
@@ -3,9 +3,8 @@
 
 import * as os from 'os';
 import * as path from 'path';
-import CommandLineBuilder from '../util/commandLineBuilder';
 import { SettingsProvider } from './settingsProvider';
-import { Process } from '../util/process';
+import LocalTyeCliClient from './tyeCliClient';
 
 export interface TyePathProvider {
     getTyePath() : Promise<string>;
@@ -35,13 +34,12 @@ export default class LocalTyePathProvider implements TyePathProvider {
     {
         try
         {
-            const commandLineBuilder = CommandLineBuilder.create('tye', '--version');
-            const result = await Process.exec(commandLineBuilder.build());
+            const tyePath = 'tye';
+            const tyeCliClient = new LocalTyeCliClient(() => Promise.resolve(tyePath));
 
-            if (result.code === 0)
-            {
-                return 'tye';
-            }
+            await tyeCliClient.version();
+                
+            return tyePath;
         }
         catch
         {

--- a/src/services/userInput.ts
+++ b/src/services/userInput.ts
@@ -16,6 +16,7 @@ export interface WizardStep<T> {
 }
 
 export interface UserInput {
+    executeCommand(command: string, ...rest: unknown[]): Promise<void>;
     openExternal(url: string): Promise<boolean>;
     showInputBox(options: vscode.InputBoxOptions): Promise<string>;
     showIssueReporter(): Promise<void>;
@@ -52,6 +53,10 @@ class WizardPromptStep<T> extends AzureWizardPromptStep<WizardContext<T>> {
 
 export class AggregateUserInput implements UserInput {
     constructor(private readonly ui: IAzureUserInput) {
+    }
+
+    async executeCommand(command: string, ...rest: unknown[]): Promise<void> {
+        await vscode.commands.executeCommand(command, ...rest);
     }
 
     async openExternal(url: string): Promise<boolean> {

--- a/src/test/suite/integration/ingressService.test.ts
+++ b/src/test/suite/integration/ingressService.test.ts
@@ -11,6 +11,7 @@ import { TyeClient } from '../../../services/tyeClient';
 import { MockTyeApplicationProvider } from './mockTyeApplicationProvider';
 import { MockTyeClient } from './mockTyeClient';
 import { TyeInstallationManager } from '../../../services/tyeInstallationManager';
+import { UserInput } from '../../../services/userInput';
 
 suite('integration/ingressServiceTests', () => {
 
@@ -23,7 +24,7 @@ suite('integration/ingressServiceTests', () => {
 
     async function buildTestProvider(): Promise<TyeServicesTreeDataProvider> {
         const testClient = await buildTestClient();
-        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient, <TyeInstallationManager>{});
+        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient, <TyeInstallationManager>{}, <UserInput>{});
     }
 
     test('TestMockClient', async () => {

--- a/src/test/suite/integration/ingressService.test.ts
+++ b/src/test/suite/integration/ingressService.test.ts
@@ -10,6 +10,7 @@ import { TyeServicesTreeDataProvider } from '../../../views/services/tyeServices
 import { TyeClient } from '../../../services/tyeClient';
 import { MockTyeApplicationProvider } from './mockTyeApplicationProvider';
 import { MockTyeClient } from './mockTyeClient';
+import { TyeInstallationManager } from '../../../services/tyeInstallationManager';
 
 suite('integration/ingressServiceTests', () => {
 
@@ -22,7 +23,7 @@ suite('integration/ingressServiceTests', () => {
 
     async function buildTestProvider(): Promise<TyeServicesTreeDataProvider> {
         const testClient = await buildTestClient();
-        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient);
+        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient, <TyeInstallationManager>{});
     }
 
     test('TestMockClient', async () => {

--- a/src/test/suite/integration/ingressService.test.ts
+++ b/src/test/suite/integration/ingressService.test.ts
@@ -10,8 +10,8 @@ import { TyeServicesTreeDataProvider } from '../../../views/services/tyeServices
 import { TyeClient } from '../../../services/tyeClient';
 import { MockTyeApplicationProvider } from './mockTyeApplicationProvider';
 import { MockTyeClient } from './mockTyeClient';
-import { TyeInstallationManager } from '../../../services/tyeInstallationManager';
-import { UserInput } from '../../../services/userInput';
+import MockTyeInstallationManager from './mockTyeInstallationManager';
+import MockUserInput from './mockUserInput';
 
 suite('integration/ingressServiceTests', () => {
 
@@ -24,7 +24,7 @@ suite('integration/ingressServiceTests', () => {
 
     async function buildTestProvider(): Promise<TyeServicesTreeDataProvider> {
         const testClient = await buildTestClient();
-        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient, <TyeInstallationManager>{}, <UserInput>{});
+        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient, new MockTyeInstallationManager(), new MockUserInput());
     }
 
     test('TestMockClient', async () => {

--- a/src/test/suite/integration/mockTyeInstallationManager.ts
+++ b/src/test/suite/integration/mockTyeInstallationManager.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { TyeInstallationManager } from '../../../services/tyeInstallationManager';
+
+export default class MockTyeInstallationManager implements TyeInstallationManager {
+    constructor(private readonly _isInstalled: boolean = true) {
+    }
+
+    ensureInstalled(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    ensureInstalledVersion(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    isInstalled(): Promise<boolean> {
+        return Promise.resolve(this._isInstalled);
+    }
+
+    isVersionInstalled(): Promise<boolean> {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/src/test/suite/integration/mockUserInput.ts
+++ b/src/test/suite/integration/mockUserInput.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { QuickPickItem, MessageItem } from 'vscode';
+import { UserInput } from '../../../services/userInput';
+
+export default class MockUserInput implements UserInput {
+    executeCommand(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    openExternal(): Promise<boolean> {
+        throw new Error('Method not implemented.');
+    }
+
+    showInputBox(): Promise<string> {
+        throw new Error('Method not implemented.');
+    }
+
+    showIssueReporter(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    showQuickPick<T extends QuickPickItem>(): Promise<T> {
+        throw new Error('Method not implemented.');
+    }
+
+    showWarningMessage<T extends MessageItem>(): Promise<T> {
+        throw new Error('Method not implemented.');
+    }
+
+    showWizard<T>(): Promise<T> {
+        throw new Error('Method not implemented.');
+    }
+
+    withProgress<T>(): Promise<T> {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/src/test/suite/integration/tyeServiceProvider.test.ts
+++ b/src/test/suite/integration/tyeServiceProvider.test.ts
@@ -10,6 +10,7 @@ import { TyeServicesTreeDataProvider } from '../../../views/services/tyeServices
 import { TyeClient } from '../../../services/tyeClient';
 import { MockTyeApplicationProvider } from './mockTyeApplicationProvider';
 import { MockTyeClient } from './mockTyeClient';
+import { TyeInstallationManager } from '../../../services/tyeInstallationManager';
 
 suite('integration/tyeServiceProvider', () => {
 
@@ -23,7 +24,7 @@ suite('integration/tyeServiceProvider', () => {
     async function buildTestProvider(): Promise<TyeServicesTreeDataProvider> {
         const testClient = await buildTestClient();
 
-        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient);
+        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient, <TyeInstallationManager>{});
     }
 
     test('TestMockClient', async () => {

--- a/src/test/suite/integration/tyeServiceProvider.test.ts
+++ b/src/test/suite/integration/tyeServiceProvider.test.ts
@@ -11,6 +11,7 @@ import { TyeClient } from '../../../services/tyeClient';
 import { MockTyeApplicationProvider } from './mockTyeApplicationProvider';
 import { MockTyeClient } from './mockTyeClient';
 import { TyeInstallationManager } from '../../../services/tyeInstallationManager';
+import { UserInput } from '../../../services/userInput';
 
 suite('integration/tyeServiceProvider', () => {
 
@@ -24,7 +25,7 @@ suite('integration/tyeServiceProvider', () => {
     async function buildTestProvider(): Promise<TyeServicesTreeDataProvider> {
         const testClient = await buildTestClient();
 
-        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient, <TyeInstallationManager>{});
+        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient, <TyeInstallationManager>{}, <UserInput>{});
     }
 
     test('TestMockClient', async () => {

--- a/src/test/suite/integration/tyeServiceProvider.test.ts
+++ b/src/test/suite/integration/tyeServiceProvider.test.ts
@@ -10,8 +10,8 @@ import { TyeServicesTreeDataProvider } from '../../../views/services/tyeServices
 import { TyeClient } from '../../../services/tyeClient';
 import { MockTyeApplicationProvider } from './mockTyeApplicationProvider';
 import { MockTyeClient } from './mockTyeClient';
-import { TyeInstallationManager } from '../../../services/tyeInstallationManager';
-import { UserInput } from '../../../services/userInput';
+import MockTyeInstallationManager from './mockTyeInstallationManager';
+import MockUserInput from './mockUserInput';
 
 suite('integration/tyeServiceProvider', () => {
 
@@ -25,7 +25,7 @@ suite('integration/tyeServiceProvider', () => {
     async function buildTestProvider(): Promise<TyeServicesTreeDataProvider> {
         const testClient = await buildTestClient();
 
-        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient, <TyeInstallationManager>{}, <UserInput>{});
+        return new TyeServicesTreeDataProvider(new MockTyeApplicationProvider(), () => testClient, new MockTyeInstallationManager(), new MockUserInput());
     }
 
     test('TestMockClient', async () => {

--- a/src/views/help/getStartedNode.ts
+++ b/src/views/help/getStartedNode.ts
@@ -14,7 +14,7 @@ export default class GetStartedNode implements TreeNode {
 
         treeItem.command = {
             arguments: [ this ],
-            command: 'vscode-tye.help.getStarted',
+            command: 'vscode-tye.commands.help.getStarted',
             title: '' // NOTE: Title is required but unused here.
         };
 

--- a/src/views/help/readDocumentationNode.ts
+++ b/src/views/help/readDocumentationNode.ts
@@ -14,7 +14,7 @@ export default class ReadDocumentationNode implements TreeNode {
 
         treeItem.command = {
             arguments: [ this ],
-            command: 'vscode-tye.help.readDocumentation',
+            command: 'vscode-tye.commands.help.readDocumentation',
             title: '' // NOTE: Title is required but unused here.
         };
 

--- a/src/views/help/reportIssueNode.ts
+++ b/src/views/help/reportIssueNode.ts
@@ -14,7 +14,7 @@ export default class ReportIssueNode implements TreeNode {
 
         treeItem.command = {
             arguments: [ this ],
-            command: 'vscode-tye.help.reportIssue',
+            command: 'vscode-tye.commands.help.reportIssue',
             title: '' // NOTE: Title is required but unused here.
         };
 

--- a/src/views/help/reviewIssuesNode.ts
+++ b/src/views/help/reviewIssuesNode.ts
@@ -14,7 +14,7 @@ export default class ReviewIssuesNode implements TreeNode {
 
         treeItem.command = {
             arguments: [ this ],
-            command: 'vscode-tye.help.reviewIssues',
+            command: 'vscode-tye.commands.help.reviewIssues',
             title: '' // NOTE: Title is required but unused here.
         };
 

--- a/src/views/services/tyeServicesTreeDataProvider.ts
+++ b/src/views/services/tyeServicesTreeDataProvider.ts
@@ -8,6 +8,7 @@ import TreeNode from '../treeNode';
 import { TyeApplicationNode } from './tyeApplicationNode';
 import { TyeClientProvider } from '../../services/tyeClient';
 import { TyeInstallationManager } from '../../services/tyeInstallationManager';
+import { UserInput } from '../../services/userInput';
 
 export class TyeServicesTreeDataProvider extends vscode.Disposable implements vscode.TreeDataProvider<TreeNode> {
     private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<void | TreeNode | null | undefined>();
@@ -17,7 +18,8 @@ export class TyeServicesTreeDataProvider extends vscode.Disposable implements vs
     constructor(
         tyeApplicationProvider: TyeApplicationProvider,
         private readonly tyeClientProvider: TyeClientProvider,
-        private readonly tyeInstallationManager: TyeInstallationManager) {
+        private readonly tyeInstallationManager: TyeInstallationManager,
+        private readonly ui: UserInput) {
         super(
             () => {
                 this.listener.unsubscribe();
@@ -54,7 +56,7 @@ export class TyeServicesTreeDataProvider extends vscode.Disposable implements vs
         if (children.length === 0) {
             const isInstalled = await this.tyeInstallationManager.isInstalled();
 
-            await vscode.commands.executeCommand('setContext', 'vscode-tye.views.services.state', isInstalled ? 'notRunning' : 'notInstalled');
+            await this.ui.executeCommand('setContext', 'vscode-tye.views.services.state', isInstalled ? 'notRunning' : 'notInstalled');
         }
 
         return children;

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,6 +345,11 @@
   resolved "https://registry.yarnpkg.com/@types/ps-tree/-/ps-tree-1.1.0.tgz#7e2034e8ccdc16f6b0ced7a88529ebcb3b1dc424"
   integrity sha512-rm5GU5sefQpg2d/DQ+fMDZnl9aPiJjJ9FYA12isIocNTZqu9VDZRgCRBx3oYFEdmDpmPmY4hxxmY/+1a84Rtzg==
 
+"@types/semver@^7.3.6":
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.6.tgz#e9831776f4512a7ba6da53e71c26e5fb67882d63"
+  integrity sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==
+
 "@types/terser-webpack-plugin@^5.0.3":
   version "5.0.3"
   resolved "https://registry.npmjs.org/@types/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz"


### PR DESCRIPTION
Ensures a valid version of Tye has been installed before attempting to perform Tye-related operations. If none found, prompt the user to install the latest version. The extension will remember versions of Tye asked for that are "satisified" by the current version, to ensure the user can install updates without requiring the extension be restarted but also to ensure we needn't constantly spawn processes to obtain the current Tye version.

If no Tye applications are found and no compatible Tye version found, the Tye Services explorer will show:

<img width="399" alt="Screenshot 2021-06-11 at 14 37 35" src="https://user-images.githubusercontent.com/6402946/121751832-cce62380-cac3-11eb-9f11-4b6ba2c993f0.png">

If a Tye-related operation is attempted without a compatible Tye version (e.g. initializing Tye or debugging a Tye application), the following error will show:

<img width="479" alt="Screenshot 2021-06-11 at 14 37 54" src="https://user-images.githubusercontent.com/6402946/121751848-d1aad780-cac3-11eb-8a8d-7635a2b35f44.png">

In both cases, the button will open a browser to (currently) the getting started document for Tye (which describes how to install Tye).  The `aka.ms` link can be changed to whatever eventual installation landing page we create in the future.

Resolves: #64 