### PR TITLE
Reduce Tye application refresh frequency

### DIFF
--- a/src/services/tyeProcessProvider.ts
+++ b/src/services/tyeProcessProvider.ts
@@ -17,7 +17,7 @@ export interface TyeProcessProvider {
 }
 
 function tyeProcessComparer(x: TyeProcess, y: TyeProcess): boolean {
-    return x.pid !== y.pid || x.dashboardPort !== y.dashboardPort;
+    return x.pid === y.pid && x.dashboardPort === y.dashboardPort;
 }
 
 function tyeProcessesComparer(x: TyeProcess[], y: TyeProcess[]): boolean {

--- a/src/services/tyeProcessProvider.ts
+++ b/src/services/tyeProcessProvider.ts
@@ -3,6 +3,7 @@
 
 import { Observable, timer } from 'rxjs'
 import { distinctUntilChanged, first, switchMap } from 'rxjs/operators';
+import { arrayComparer } from '../util/comparison';
 import { PortProvider } from './portProvider';
 import { ProcessProvider } from './processProvider';
 
@@ -21,22 +22,7 @@ function tyeProcessComparer(x: TyeProcess, y: TyeProcess): boolean {
 }
 
 function tyeProcessesComparer(x: TyeProcess[], y: TyeProcess[]): boolean {
-    if (x.length !== y.length) {
-        return false;
-    }
-
-    const byPid = (a: TyeProcess, b: TyeProcess) => a.pid - b.pid;
-
-    x = x.slice().sort(byPid);
-    y = y.slice().sort(byPid);
-
-    for (let i = 0; i < x.length; i++) {
-        if (!tyeProcessComparer(x[i], y[i])) {
-            return false;
-        }
-    }
-
-    return true;
+    return arrayComparer(x, y, (a: TyeProcess, b: TyeProcess) => a.pid - b.pid, tyeProcessComparer);
 }
 
 type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/src/test/suite/integration/mockTyeApplicationProvider.ts
+++ b/src/test/suite/integration/mockTyeApplicationProvider.ts
@@ -9,6 +9,7 @@ export class MockTyeApplicationProvider implements TyeApplicationProvider{
     private static Applications: TyeApplication[] = [
         {
             dashboard: vscode.Uri.parse('http://localhost:8000'),
+            id: '1234',
             name: 'app',
             projectServices: {}
         }

--- a/src/util/comparison.ts
+++ b/src/util/comparison.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 export function arrayComparer<T>(x: T[], y: T[], sorter: (a: T, b: T) => number, comparer: (x: T, y: T) => boolean): boolean {
     if (x.length !== y.length) {
         return false;

--- a/src/util/comparison.ts
+++ b/src/util/comparison.ts
@@ -1,0 +1,16 @@
+export function arrayComparer<T>(x: T[], y: T[], sorter: (a: T, b: T) => number, comparer: (x: T, y: T) => boolean): boolean {
+    if (x.length !== y.length) {
+        return false;
+    }
+
+    x = x.slice().sort(sorter);
+    y = y.slice().sort(sorter);
+
+    for (let i = 0; i < x.length; i++) {
+        if (!comparer(x[i], y[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/views/services/tyeApplicationNode.ts
+++ b/src/views/services/tyeApplicationNode.ts
@@ -11,7 +11,10 @@ import { TyeClientProvider } from '../../services/tyeClient';
 import ext from '../../ext';
 
 export class TyeApplicationNode implements TreeNode {
+    private readonly id: string;
+
     constructor(private readonly application: TyeApplication, private readonly tyeClientProvider: TyeClientProvider) {
+        this.id = `vscode-tye.views.services.${this.application.id}`;  
     }
 
     async getChildren(): Promise<TreeNode[]> {
@@ -31,9 +34,9 @@ export class TyeApplicationNode implements TreeNode {
             return [];
         }
 
-        const nodes: TreeNode[] = [ new TyeDashboardNode(this.application.dashboard)];
+        const nodes: TreeNode[] = [ new TyeDashboardNode(this.application.dashboard, this.id)];
         
-        return nodes.concat(services.map(service => new TyeServiceNode(this.application, service)));
+        return nodes.concat(services.map(service => new TyeServiceNode(this.application, service, this.id)));
     }
 
     getTreeItem(): vscode.TreeItem {
@@ -48,8 +51,7 @@ export class TyeApplicationNode implements TreeNode {
             dark: path.join(resourcesPath, 'brand-tye-white.svg')
         };
 
-        // TODO: Add application ID.
-        treeItem.id = `vscode-tye.views.services.${this.application.name}`;
+        treeItem.id = this.id;
 
         return treeItem;
     }

--- a/src/views/services/tyeApplicationNode.ts
+++ b/src/views/services/tyeApplicationNode.ts
@@ -37,7 +37,7 @@ export class TyeApplicationNode implements TreeNode {
     }
 
     getTreeItem(): vscode.TreeItem {
-        const treeItem = new vscode.TreeItem(this.application.name, vscode.TreeItemCollapsibleState.Collapsed);
+        const treeItem = new vscode.TreeItem(this.application.name, vscode.TreeItemCollapsibleState.Expanded);
 
         treeItem.contextValue = 'application';
 

--- a/src/views/services/tyeApplicationNode.ts
+++ b/src/views/services/tyeApplicationNode.ts
@@ -37,7 +37,7 @@ export class TyeApplicationNode implements TreeNode {
     }
 
     getTreeItem(): vscode.TreeItem {
-        const treeItem = new vscode.TreeItem(this.application.name, vscode.TreeItemCollapsibleState.Expanded);
+        const treeItem = new vscode.TreeItem(this.application.name, vscode.TreeItemCollapsibleState.Collapsed);
 
         treeItem.contextValue = 'application';
 
@@ -47,6 +47,9 @@ export class TyeApplicationNode implements TreeNode {
             light: path.join(resourcesPath, 'brand-tye-darkgray.svg'),
             dark: path.join(resourcesPath, 'brand-tye-white.svg')
         };
+
+        // TODO: Add application ID.
+        treeItem.id = `vscode-tye.views.services.${this.application.name}`;
 
         return treeItem;
     }

--- a/src/views/services/tyeDashboardNode.ts
+++ b/src/views/services/tyeDashboardNode.ts
@@ -9,7 +9,10 @@ import TyeNode from '../treeNode';
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
 export class TyeDashboardNode implements TyeNode {
-    constructor(private readonly dashboard: vscode.Uri) {
+    private readonly id: string;
+
+    constructor(private readonly dashboard: vscode.Uri, parentId: string) {
+        this.id = `${parentId}.dashboard`;
     }
 
     getTreeItem(): vscode.TreeItem {
@@ -22,8 +25,8 @@ export class TyeDashboardNode implements TyeNode {
         };
 
         treeItem.contextValue = 'information';
-
-        treeItem.iconPath = new vscode.ThemeIcon('dashboard');
+        treeItem.iconPath = new vscode.ThemeIcon('dashboard');       
+        treeItem.id = this.id;
 
         return treeItem;
     }

--- a/src/views/services/tyeReplicaNode.ts
+++ b/src/views/services/tyeReplicaNode.ts
@@ -41,7 +41,10 @@ export function isAttachable(service: TyeService): boolean {
 }
 
 export default class TyeReplicaNode implements TyeNode {
-    constructor(public readonly service: TyeService, public readonly replica: TyeReplica) {
+    private readonly id: string;
+
+    constructor(public readonly service: TyeService, public readonly replica: TyeReplica, parentId: string) {
+        this.id = `${parentId}.${replica.name}`;
     }
 
     getTreeItem(): vscode.TreeItem {
@@ -49,6 +52,7 @@ export default class TyeReplicaNode implements TyeNode {
 
         treeItem.contextValue = this.service.serviceType;
         treeItem.iconPath = new vscode.ThemeIcon('server-process');
+        treeItem.id = this.id;
 
         if (isAttachable(this.service)) {
             // TODO: Disable debugging when no workspace is open.  (Does it matter?  What if the *wrong* workspace is currently open?)

--- a/src/views/services/tyeServiceNode.ts
+++ b/src/views/services/tyeServiceNode.ts
@@ -7,12 +7,15 @@ import TyeNode from '../treeNode';
 import TyeReplicaNode, { getReplicaBrowseUrl, isAttachable, isReplicaBrowsable } from './tyeReplicaNode';
 
 export default class TyeServiceNode implements TyeNode {
-    constructor(public readonly application: TyeApplication, public readonly service: TyeService) {
+    private readonly id: string;
+
+    constructor(public readonly application: TyeApplication, public readonly service: TyeService, private parentId: string) {
+        this.id = `${parentId}.${service.description.name}`;
     }
 
     getChildren(): TyeNode[] {
         return this.service.replicas
-            ? Object.values(this.service.replicas).map(replica => new TyeReplicaNode(this.service, replica))
+            ? Object.values(this.service.replicas).map(replica => new TyeReplicaNode(this.service, replica, this.id))
             : [];
     }
 
@@ -20,8 +23,9 @@ export default class TyeServiceNode implements TyeNode {
         const treeItem = new vscode.TreeItem(this.service.description.name, vscode.TreeItemCollapsibleState.Collapsed);
 
         treeItem.contextValue = this.service.serviceType;
-
         treeItem.contextValue += ' hasLogs'
+
+        treeItem.id = this.id;
 
         if (isAttachable(this.service)) {
             // TODO: Disable debugging when no workspace is open.  (Does it matter?  What if the *wrong* workspace is currently open?)
@@ -33,8 +37,6 @@ export default class TyeServiceNode implements TyeNode {
         } else {
             treeItem.iconPath = new vscode.ThemeIcon('project');
         }
-
-        treeItem.id = `vscode-tye.views.services.${this.application.name}.${this.service.description.name}`;
 
         if (this.isBrowsable) {
             treeItem.contextValue += ' browsable';

--- a/src/views/services/tyeServiceNode.ts
+++ b/src/views/services/tyeServiceNode.ts
@@ -34,6 +34,8 @@ export default class TyeServiceNode implements TyeNode {
             treeItem.iconPath = new vscode.ThemeIcon('project');
         }
 
+        treeItem.id = `vscode-tye.views.services.${this.application.name}.${this.service.description.name}`;
+
         if (this.isBrowsable) {
             treeItem.contextValue += ' browsable';
         }


### PR DESCRIPTION
Fixes an inverted comparison function that caused the Tye applications tree view to refresh on each timer-tick rather than only when actually changed (as intended).  This resulted in an apparent behavior where a collapsed application node would nearly immediately re-expand.

Also refactors some of the comparison code to reduce duplication, and adds explicit IDs to each node (which is used by VS Code to remember node state across refreshes).

Note that this isn't a complete fix, due to an apparent issue in VS Code itself related to expanded-by-default nodes (see the related issue).

Related to #106.