### PR TITLE
Add shutdown application command

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"onCommand:vscode-tye.commands.scaffolding.initTye",
 		"onCommand:vscode-tye.commands.scaffolding.scaffoldTyeTasks",
 		"onCommand:vscode-tye.commands.showLogs",
+		"onCommand:vscode-tye.commands.shutdownApplication",
 		"onCommand:vscode-tye.commands.help.getStarted",
 		"onCommand:vscode-tye.commands.help.installTye",
 		"onCommand:vscode-tye.commands.help.readDocumentation",
@@ -245,6 +246,12 @@
 				"icon": "$(output)"
 			},
 			{
+				"category": "Tye",
+				"command": "vscode-tye.commands.shutdownApplication",
+				"title": "%vscode-tye.commands.shutdownApplication.title%",
+				"icon": "$(debug-stop)"
+			},
+			{
 				"command": "vscode-tye.commands.help.getStarted",
 				"title": "%vscode-tye.commands.help.getStarted.title%",
 				"category": "Tye"
@@ -300,6 +307,10 @@
 				{
 					"command": "vscode-tye.commands.showLogs",
 					"when": "never"
+				},
+				{
+					"command": "vscode-tye.commands.shutdownApplication",
+					"when": "never"
 				}
 			],
 			"view/title": [
@@ -312,6 +323,11 @@
 			"view/item/context": [
 				{
 					"command": "vscode-tye.commands.debugAll",
+					"when": "view == vscode-tye.views.services && viewItem =~ /application/",
+					"group": "inline"
+				},
+				{
+					"command": "vscode-tye.commands.shutdownApplication",
 					"when": "view == vscode-tye.views.services && viewItem =~ /application/",
 					"group": "inline"
 				},

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,7 +2,7 @@
     "vscode-tye.activityBar.microsoft-tye.title": "Tye",
 
     "vscode-tye.commands.refreshEntry.title": "Refresh",
-    "vscode-tye.commands.debugAll.title": "Debug",
+    "vscode-tye.commands.debugAll.title": "Attach",
     "vscode-tye.commands.browseService.title": "Browse",
     "vscode-tye.commands.attachService.title": "Attach",
     "vscode-tye.commands.scaffolding.initTye.title": "Initialize Tye",

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,6 +8,7 @@
     "vscode-tye.commands.scaffolding.initTye.title": "Initialize Tye",
     "vscode-tye.commands.scaffolding.scaffoldTyeTasks.title": "Scaffold Tye Tasks",
     "vscode-tye.commands.showLogs.title": "Logs",
+    "vscode-tye.commands.shutdownApplication.title": "Shutdown",
     "vscode-tye.commands.help.getStarted.title": "Get Started",
     "vscode-tye.commands.help.installTye.title": "Install Tye",
     "vscode-tye.commands.help.readDocumentation.title": "Read Documentation",

--- a/src/commands/browseService.ts
+++ b/src/commands/browseService.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { UserInput } from '../services/userInput';
 import { IActionContext } from 'vscode-azureextensionui';
 import TreeNode from '../views/treeNode';

--- a/src/commands/shutdownApplication.ts
+++ b/src/commands/shutdownApplication.ts
@@ -8,10 +8,11 @@ import { IActionContext } from 'vscode-azureextensionui';
 import TreeNode from '../views/treeNode';
 import { TyeApplicationNode } from '../views/services/tyeApplicationNode';
 import { getLocalizationPathForFile } from '../util/localization';
+import { TyeClientProvider } from '../services/tyeClient';
 
 const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
 
-export async function shutdownApplication(ui: UserInput, context: IActionContext, node: TreeNode): Promise<void> {
+export async function shutdownApplication(tyeClientProvider: TyeClientProvider, ui: UserInput, context: IActionContext, node: TreeNode): Promise<void> {
     if (node instanceof TyeApplicationNode) {
         const shutdown: vscode.MessageItem = { title: localize('commands.shutdownApplication.shutdown', 'Shutdown') };
 
@@ -22,12 +23,17 @@ export async function shutdownApplication(ui: UserInput, context: IActionContext
 
         if(result === shutdown)
         {
-            // TODO: Implement me!
-            await Promise.resolve();
+            const tyeClient = tyeClientProvider(node.application.dashboard);
+
+            if (!tyeClient) {
+                throw new Error(localize('commands.shutdownApplication.noClient', 'Unable to establish a connection to the application.'));
+            }
+
+            await tyeClient.shutDown();
         }
     }
 }
 
-const createShutdownApplicationCommand = (ui: UserInput) => (context: IActionContext, applicationNode: TyeApplicationNode): Promise<void> => shutdownApplication(ui, context, applicationNode);
+const createShutdownApplicationCommand = (tyeClientProvider: TyeClientProvider, ui: UserInput) => (context: IActionContext, applicationNode: TyeApplicationNode): Promise<void> => shutdownApplication(tyeClientProvider, ui, context, applicationNode);
 
 export default createShutdownApplicationCommand;

--- a/src/commands/shutdownApplication.ts
+++ b/src/commands/shutdownApplication.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
+import { UserInput } from '../services/userInput';
+import { IActionContext } from 'vscode-azureextensionui';
+import TreeNode from '../views/treeNode';
+import { TyeApplicationNode } from '../views/services/tyeApplicationNode';
+import { getLocalizationPathForFile } from '../util/localization';
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+export async function shutdownApplication(ui: UserInput, context: IActionContext, node: TreeNode): Promise<void> {
+    if (node instanceof TyeApplicationNode) {
+        const shutdown: vscode.MessageItem = { title: localize('commands.shutdownApplication.shutdown', 'Shutdown') };
+
+        const result = await ui.showWarningMessage(
+                localize('commands.shutdownApplication.areYouSurePrompt', 'Shutdown Tye application "{0}"?', node.application.name),
+                { modal: true },
+                shutdown);
+
+        if(result === shutdown)
+        {
+            // TODO: Implement me!
+            await Promise.resolve();
+        }
+    }
+}
+
+const createShutdownApplicationCommand = (ui: UserInput) => (context: IActionContext, applicationNode: TyeApplicationNode): Promise<void> => shutdownApplication(ui, context, applicationNode);
+
+export default createShutdownApplicationCommand;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,7 @@ import createInstallTyeCommand from './commands/help/installTye';
 import LocalTyeProcessProvider from './services/tyeProcessProvider';
 import createPlatformProcessProvider from './services/processProvider';
 import LocalPortProvider from './services/portProvider';
+import createShutdownApplicationCommand from './commands/shutdownApplication';
 
 interface ExtensionPackage {
 	engines: { [key: string]: string };
@@ -107,6 +108,10 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 					}
 				});
 
+			telemetryProvider.registerCommandWithTelemetry(
+				'vscode-tye.commands.shutdownApplication',
+				createShutdownApplicationCommand(ui));
+	
 			const debugSessionMonitor = registerDisposable(new CoreClrDebugSessionMonitor());
 
 			telemetryProvider.registerCommandWithTelemetry(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,7 +110,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 
 			telemetryProvider.registerCommandWithTelemetry(
 				'vscode-tye.commands.shutdownApplication',
-				createShutdownApplicationCommand(ui));
+				createShutdownApplicationCommand(tyeClientProvider, ui));
 	
 			const debugSessionMonitor = registerDisposable(new CoreClrDebugSessionMonitor());
 

--- a/src/views/services/tyeApplicationNode.ts
+++ b/src/views/services/tyeApplicationNode.ts
@@ -11,7 +11,7 @@ import { TyeClientProvider } from '../../services/tyeClient';
 import ext from '../../ext';
 
 export class TyeApplicationNode implements TreeNode {
-    constructor(private readonly application: TyeApplication, private readonly tyeClientProvider: TyeClientProvider) {
+    constructor(public readonly application: TyeApplication, private readonly tyeClientProvider: TyeClientProvider) {
     }
 
     async getChildren(): Promise<TreeNode[]> {


### PR DESCRIPTION
Adds a shutdown command for application nodes in the Tye applications tree view.  The command invokes the shutdown method of Tye's control plane.  The user will be prompted to confirm the shutdown.

<img width="385" alt="Screenshot 2021-07-01 at 14 02 10" src="https://user-images.githubusercontent.com/6402946/124189030-f10aa400-da74-11eb-83d1-c2963fe78bc6.png">

Also updates the text of the application's debug-all command to "attach" to match text used by the command that attaches to individual services.

Resolves #24.
Resolves #109.