### PR TITLE
Reattach only when related application changes

### DIFF
--- a/src/debug/tyeApplicationWatcher.ts
+++ b/src/debug/tyeApplicationWatcher.ts
@@ -8,7 +8,7 @@ import { TyeApplicationProvider } from '../services/tyeApplicationProvider';
 import { attachToReplica } from './attachToReplica';
 
 export interface TyeApplicationWatcher {
-    watchApplication(applicationName: string, options?: { folder?: vscode.WorkspaceFolder, services?: string[] }): void;
+    watchApplication(applicationId: string, options?: { folder?: vscode.WorkspaceFolder, services?: string[] }): void;
 }
 
 type WatchedApplication = {
@@ -31,8 +31,8 @@ export class TyeApplicationDebugSessionWatcher extends vscode.Disposable impleme
                 .applications
                 .subscribe(
                     applications => {
-                        for (const watchedApplicationName of Object.keys(this.watchedApplications)) {
-                            const application = applications.find(a => a.name === watchedApplicationName);
+                        for (const watchedApplicationId of Object.keys(this.watchedApplications)) {
+                            const application = applications.find(a => a.id === watchedApplicationId);
 
                             if (application) {
                                 // Application is still running, see if new replicas need attaching to...
@@ -41,7 +41,7 @@ export class TyeApplicationDebugSessionWatcher extends vscode.Disposable impleme
                                     continue;
                                 }
 
-                                const watchedApplication = this.watchedApplications[watchedApplicationName];
+                                const watchedApplication = this.watchedApplications[watchedApplicationId];
 
                                 for (const serviceName of Object.keys(application.projectServices)) {
                                     if (watchedApplication.services === undefined || watchedApplication.services.includes(serviceName)) {
@@ -56,15 +56,15 @@ export class TyeApplicationDebugSessionWatcher extends vscode.Disposable impleme
                                 }
                             } else {
                                 // Application is no longer running, stop watching...
-                                delete this.watchedApplications[watchedApplicationName];
+                                delete this.watchedApplications[watchedApplicationId];
                             }
                         }
                     });
     }
 
-    watchApplication(applicationName: string, options?: { folder?: vscode.WorkspaceFolder, services?: string[] }): void {
+    watchApplication(applicationId: string, options?: { folder?: vscode.WorkspaceFolder, services?: string[] }): void {
         const { folder, services } = options ?? {};
 
-        this.watchedApplications[applicationName] = { folder, services };
+        this.watchedApplications[applicationId] = { folder, services };
     }
 }

--- a/src/debug/tyeDebugConfigurationProvider.ts
+++ b/src/debug/tyeDebugConfigurationProvider.ts
@@ -28,6 +28,9 @@ export class TyeDebugConfigurationProvider implements vscode.DebugConfigurationP
         const tyeDebugConfiguration = <TyeDebugConfiguration>debugConfiguration;
 
         const applications = await this.tyeApplicationProvider.getApplications();
+
+        // NOTE: In the unlikely event of multiple same-named applications running, we arbitrarily use the first match.
+        // TODO: Cache applications started via our `tye-run` tasks, and give preference to those.
         const application = applications.find(a => a.name === tyeDebugConfiguration.applicationName);
 
         if (!application) {
@@ -61,7 +64,7 @@ export class TyeDebugConfigurationProvider implements vscode.DebugConfigurationP
         }
 
         if (tyeDebugConfiguration.watch) {
-            this.tyeApplicationWatcher.watchApplication(tyeDebugConfiguration.applicationName, { folder, services: tyeDebugConfiguration.services });
+            this.tyeApplicationWatcher.watchApplication(application.id, { folder, services: tyeDebugConfiguration.services });
         }
 
         return undefined;

--- a/src/services/tyeApplicationProvider.ts
+++ b/src/services/tyeApplicationProvider.ts
@@ -57,7 +57,15 @@ function serviceComparer(x: TyeProjectService, y: TyeProjectService): boolean {
     return true;
 }
 
-function applicationComparer(x: TyeApplication, y: TyeApplication): boolean {
+export function applicationComparer(x: TyeApplication | undefined, y: TyeApplication | undefined): boolean {
+    if (x === undefined && y === undefined) {
+        return true;
+    }
+
+    if (x === undefined || y === undefined) {
+        return false;
+    }
+
     if (x.id !== y.id
         || x.name !== y.name
         || x.dashboard.toString() !== y.dashboard.toString()


### PR DESCRIPTION
Resolves an issue when the extension would reattach to processes of an application when *any* Tye application changes (e.g. another application started/stopped).  With this change, we now listen for and react only to changes to the watched application.

Also has the debug configuration and watcher use the application's unique ID instead of name to help protect against the case when multiple applications share a name.

Related to #103.