### PR TITLE
Attach to selected application's replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change Log
 
-## v0.2.0 - 2 July 2021
+## v0.2.0 - 6 July 2021
 
 A number of usability enhancements and fixes.
 
 ### Fixed
 
+ * The microservice application's debugger is attached when clicking "Attach" button of Dapr application [#118](https://github.com/microsoft/vscode-tye/issues/118)
  * It always auto-debugs again after clicking "Disconnect/Stop" button [#103](https://github.com/microsoft/vscode-tye/issues/103)
  * The microservice node is collapsed and then re-expanded after single click the collapse icon [#106](https://github.com/microsoft/vscode-tye/issues/106)
  * Debug icon should be hidden when no application is running [#69](https://github.com/microsoft/vscode-tye/issues/69)

--- a/src/commands/shutdownApplication.ts
+++ b/src/commands/shutdownApplication.ts
@@ -6,7 +6,7 @@ import * as nls from 'vscode-nls';
 import { UserInput } from '../services/userInput';
 import { IActionContext } from 'vscode-azureextensionui';
 import TreeNode from '../views/treeNode';
-import { TyeApplicationNode } from '../views/services/tyeApplicationNode';
+import TyeApplicationNode from '../views/services/tyeApplicationNode';
 import { getLocalizationPathForFile } from '../util/localization';
 import { TyeClientProvider } from '../services/tyeClient';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,7 @@ import LocalTyeProcessProvider from './services/tyeProcessProvider';
 import createPlatformProcessProvider from './services/processProvider';
 import LocalPortProvider from './services/portProvider';
 import createShutdownApplicationCommand from './commands/shutdownApplication';
+import TyeApplicationNode from './views/services/tyeApplicationNode';
 
 interface ExtensionPackage {
 	engines: { [key: string]: string };
@@ -163,16 +164,10 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 
 			telemetryProvider.registerCommandWithTelemetry(
 				'vscode-tye.commands.debugAll',
-				async () => {
-					const applications = await tyeApplicationProvider.getApplications();
+				async (context, node: TyeApplicationNode) => {
+					const application = node.application;
 
-					// NOTE: We arbitrarily only attach to processes associated with the first application.
-					//       This matches the tree view, which also shows only that first application.
-					//       Future work will refactor the tree view and debugging for multiple applications
-					//       once Tye has better discovery support.
-					const application = applications[0];
-
-					if (application?.projectServices) {
+					if (node.application?.projectServices) {
 						for (const service of Object.values(application.projectServices)) {
 								for (const replicaName of Object.keys(service.replicas)) {
 									const pid = service.replicas[replicaName];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,7 +167,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 				async (context, node: TyeApplicationNode) => {
 					const application = node.application;
 
-					if (node.application?.projectServices) {
+					if (application?.projectServices) {
 						for (const service of Object.values(application.projectServices)) {
 								for (const replicaName of Object.keys(service.replicas)) {
 									const pid = service.replicas[replicaName];

--- a/src/views/services/tyeApplicationNode.ts
+++ b/src/views/services/tyeApplicationNode.ts
@@ -10,7 +10,7 @@ import TyeServiceNode from './tyeServiceNode';
 import { TyeClientProvider } from '../../services/tyeClient';
 import ext from '../../ext';
 
-export class TyeApplicationNode implements TreeNode {
+export default class TyeApplicationNode implements TreeNode {
     private readonly id: string;
 
     constructor(public readonly application: TyeApplication, private readonly tyeClientProvider: TyeClientProvider) {

--- a/src/views/services/tyeServicesTreeDataProvider.ts
+++ b/src/views/services/tyeServicesTreeDataProvider.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { TyeApplication, TyeApplicationProvider } from '../../services/tyeApplicationProvider';
 import { Subscription } from 'rxjs';
 import TreeNode from '../treeNode';
-import { TyeApplicationNode } from './tyeApplicationNode';
+import TyeApplicationNode from './tyeApplicationNode';
 import { TyeClientProvider } from '../../services/tyeClient';
 import { TyeInstallationManager } from '../../services/tyeInstallationManager';
 import { UserInput } from '../../services/userInput';


### PR DESCRIPTION
Fixes an issue were we were still attaching to the first application's replicas when the "debug all" command was invoked, rather than the *actually selected* application (in cases when more than one application was running).

Resolves #118.