### PR TITLE
Check for both file and full paths of running instances.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,9 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 			const httpClient = new AxiosHttpClient();
 
 			const tyeClientProvider = httpTyeClientProvider(httpClient);
-			const tyeProcessProvider = new LocalTyeProcessProvider(new LocalPortProvider(), createPlatformProcessProvider());
+			const settingsProvider = new VsCodeSettingsProvider();
+			const tyePathProvider = new LocalTyePathProvider(settingsProvider);
+			const tyeProcessProvider = new LocalTyeProcessProvider(new LocalPortProvider(), createPlatformProcessProvider(), tyePathProvider);
 			const tyeApplicationProvider = new TaskBasedTyeApplicationProvider(tyeProcessProvider, tyeClientProvider);
 
 			registerDisposable(vscode.workspace.registerTextDocumentContentProvider('tye-log', new TyeLogsContentProvider(tyeClientProvider)));
@@ -132,8 +134,6 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 				});
 
 			const scaffolder = new LocalScaffolder();
-			const settingsProvider = new VsCodeSettingsProvider();
-			const tyePathProvider = new LocalTyePathProvider(settingsProvider);
 			const tyeApplicationConfigurationProvider = new WorkspaceTyeApplicationConfigurationProvider(new YamlTyeApplicationConfigurationReader());
 
 			telemetryProvider.registerCommandWithTelemetry(

--- a/src/services/tyeProcessProvider.ts
+++ b/src/services/tyeProcessProvider.ts
@@ -6,6 +6,7 @@ import { distinctUntilChanged, first, switchMap } from 'rxjs/operators';
 import { arrayComparer } from '../util/comparison';
 import { PortProvider } from './portProvider';
 import { ProcessProvider } from './processProvider';
+import { TyePathProvider } from './tyePathProvider';
 
 export interface TyeProcess {
     pid: number;
@@ -33,7 +34,8 @@ export default class LocalTyeProcessProvider implements TyeProcessProvider {
 
     constructor(
         private readonly portProvider: PortProvider,
-        private readonly processProvider: ProcessProvider) {
+        private readonly processProvider: ProcessProvider,
+        private readonly tyePathProvider: TyePathProvider) {
         this._processes =
             // TODO: Make interval configurable.
             timer(0, 2000)
@@ -59,7 +61,8 @@ export default class LocalTyeProcessProvider implements TyeProcessProvider {
     }
 
     private async getProcessList(): Promise<TyeProcess[]> {
-        const tyeProcesses = await this.processProvider.listProcesses('tye');
+        const tyePath = await this.tyePathProvider.getTyePath();
+        const tyeProcesses = await this.processProvider.listProcesses(tyePath);
         const tyeProcessesWithPorts = await Promise.all(tyeProcesses.map(process => this.getPortForProcess(process.pid)));
 
         function hasValidPort(process: ProspectiveTyeProcess): process is TyeProcess {


### PR DESCRIPTION
On Mac/Linux, better handle cases where the user either explicitly sets the path to the `tye` executable or explicitly runs `tye` using its full path.

Resolves #120.