### PR TITLE
Accommodate custom Tye paths.

### DIFF
--- a/src/services/processProvider.ts
+++ b/src/services/processProvider.ts
@@ -14,7 +14,7 @@ export interface ProcessInfo {
 }
 
 export interface ProcessProvider {
-    listProcesses(name: string): Promise<ProcessInfo[]>;
+    listProcesses(filePath: string): Promise<ProcessInfo[]>;
 }
 
 // TODO: Consider making async.
@@ -67,8 +67,11 @@ function getWmicValue(line: string): string {
 }
 
 export class WindowsProcessProvider implements ProcessProvider {
-    async listProcesses(name: string): Promise<ProcessInfo[]> {
-        const list = await Process.exec(`wmic process where "name='${name}.exe'" get commandline,name,processid /format:list`);
+    async listProcesses(filePath: string): Promise<ProcessInfo[]> {
+        // WMIC lists processes by file name regardless of its full path.
+        const fileName = path.basename(filePath);
+
+        const list = await Process.exec(`wmic process where "name='${fileName}'" get commandline,name,processid /format:list`);
         
         // Lines in the output are delimited by "<CR><CR><LF>".
         const lines = list.stdout.split('\r\r\n');

--- a/src/services/tyePathProvider.ts
+++ b/src/services/tyePathProvider.ts
@@ -46,6 +46,6 @@ export default class LocalTyePathProvider implements TyePathProvider {
             // Best effort; In case of error, fallback to homedir.
         }
 
-        return path.join(os.homedir(), '.dotnet', 'tools', 'tye');
+        return path.join(os.homedir(), '.dotnet', 'tools', os.platform() === 'win32' ? 'tye.exe' : 'tye');
     }
 }


### PR DESCRIPTION
Better accommodate custom Tye paths on Windows by always using full file names.

Resolves #133.