### PR TITLE
Add link to license in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,7 @@ This project may contain trademarks or logos for projects, products, or services
 The Tye extension is an experimental project, and as such we expect all users to take responsibility for evaluating the security of their own applications.
 
 Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center (MSRC) secure@microsoft.com. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the Security TechCenter.
+
+## License
+
+[MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"preview": true,
 	"icon": "resources/brand-tye_128x.png",
 	"publisher": "ms-azuretools",
-	"license": "SEE LICENSE IN LICENSE.txt",
+	"license": "SEE LICENSE IN LICENSE",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"homepage": "https://github.com/Microsoft/vscode-tye/",
 	"repository": {


### PR DESCRIPTION
Adds mention/link of/to `LICENSE` in the `README.md`.  Also corrects the `license` property in `package.json` to match the actual filename, which *should* allow the VS Code Marketplace to pick it out and list it on the extension page.

Resolves #158.