### PR TITLE
Wait for application services to startup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,7 +169,7 @@ export function activate(context: vscode.ExtensionContext): Promise<void> {
 	
 			const applicationWatcher = registerDisposable(new TyeApplicationDebugSessionWatcher(debugSessionMonitor, tyeApplicationProvider));
 		
-			registerDisposable(vscode.debug.registerDebugConfigurationProvider('tye', new TyeDebugConfigurationProvider(debugSessionMonitor, tyeApplicationProvider, applicationWatcher)));
+			registerDisposable(vscode.debug.registerDebugConfigurationProvider('tye', new TyeDebugConfigurationProvider(debugSessionMonitor, tyeApplicationProvider, applicationWatcher, ui)));
 		
 			registerDisposable(vscode.tasks.registerTaskProvider('tye-run', new TyeRunCommandTaskProvider(telemetryProvider, tyeApplicationProvider, tyeClientProvider, tyeInstallationManager, tyePathProvider)));
 

--- a/src/util/observableUtil.ts
+++ b/src/util/observableUtil.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import { Observable } from 'rxjs';
+import * as nls from 'vscode-nls';
+import { getLocalizationPathForFile } from '../util/localization';
+
+const localize = nls.loadMessageBundle(getLocalizationPathForFile(__filename));
+
+export function observableFromCancellationToken<T = void>(cancellationToken: vscode.CancellationToken): Observable<T> {
+    return new Observable<T>(
+        subscriber => {
+            const listener = cancellationToken.onCancellationRequested(
+                () => {
+                    subscriber.error(new Error(localize('util.observableUtil.cancellationRequested', 'Cancellation was requested.')));
+                });
+
+            return () => {
+                listener.dispose()
+            };
+        });
+}


### PR DESCRIPTION
In some cases, the debug configuration provider was being invoked before the application had been noticed, which caused it to fail to find the application and fail to attach the debugger. This change waits up to a minute for the associated application to not only itself start, but also for each service of the application to have at least one replica running.

The extension also now shows the user a progress dialog to better indicate the wait as well as provide a mechanism to cancel it.

Resolves #161.