### PR TITLE
Switch to PowerShell WMI command

### DIFF
--- a/src/services/processProvider.ts
+++ b/src/services/processProvider.ts
@@ -61,7 +61,7 @@ export class UnixProcessProvider implements ProcessProvider {
 }
 
 interface WmiWin32ProcessObject {
-    readonly CommandLine: string;
+    readonly CommandLine: string | null;
     readonly Name: string;
     readonly ProcessId: number;
 }
@@ -85,14 +85,14 @@ export class WindowsProcessProvider implements ProcessProvider {
 
                 // NOTE: ConvertTo-Json returns a single JSON object when given a single object rather than a collection.
                 //       The -AsArray argument isn't available until PowerShell 7.0 and later.
-                
+
                 if (Array.isArray(json)) {
                     output = <WmiWin32ProcessObject[]>json;
                 } else {
                     output = [<WmiWin32ProcessObject>json];
                 }
                 
-                return output.map(o => ({ cmd: o.CommandLine, name: o.Name, pid: o.ProcessId }));
+                return output.map(o => ({ cmd: o.CommandLine ?? '', name: o.Name, pid: o.ProcessId }));
             }
             catch {       
                 // NOTE: No-op.                         

--- a/src/services/processProvider.ts
+++ b/src/services/processProvider.ts
@@ -83,6 +83,9 @@ export class WindowsProcessProvider implements ProcessProvider {
             try {
                 const json: unknown = JSON.parse(list.stdout);
 
+                // NOTE: ConvertTo-Json returns a single JSON object when given a single object rather than a collection.
+                //       The -AsArray argument isn't available until PowerShell 7.0 and later.
+                
                 if (Array.isArray(json)) {
                     output = <WmiWin32ProcessObject[]>json;
                 } else {

--- a/src/util/process.ts
+++ b/src/util/process.ts
@@ -10,7 +10,7 @@ import { awaitWithTimeout } from './promiseUtil';
 
 const localize = nls.loadMessageBundle(localization.getLocalizationPathForFile(__filename));
 
-const DEFAULT_BUFFER_SIZE = 10 * 1024; // The default Node.js `exec` buffer size is 1 MB, our actual usage is far less
+const DEFAULT_BUFFER_SIZE = 24 * 1024; // The default Node.js `exec` buffer size is 1 MB, our actual usage is far less
 
 function bufferToString(buffer: Buffer): string {
     // Node.js treats null bytes as part of the length, which makes everything mad
@@ -79,7 +79,7 @@ export class Process extends vscode.Disposable {
 
                 // Without the shell option, it pukes on arguments
                 options = options || {};
-                options.shell = true;
+                options.shell ??= true;
 
                 const process = cp.spawn(command, options);
 


### PR DESCRIPTION
Replaces use of the Windows 11 deprecated `wmic.exe` utility with its PowerShell equivalent (which is now the recommended means of querying WMI).

Resolves #163.