### PR TITLE
Make application matching case-insensitive.

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,10 +97,6 @@
 			{
 				"type": "tye-run",
 				"properties": {
-					"applicationName": {
-						"type": "string",
-						"description": "%vscode-tye.tasks.tye-run.properties.applicationName.description%"
-					},
 					"build": {
 						"type": "string",
 						"description": "%vscode-tye.tasks.tye-run.properties.build.description%"
@@ -167,10 +163,7 @@
 						"type": "boolean",
 						"description": "%vscode-tye.tasks.tye-run.properties.watch.description%"
 					}
-				},
-				"required": [
-					"applicationName"
-				]
+				}
 			}
 		],
 		"viewsWelcome": [

--- a/src/commands/scaffolding/scaffoldTyeTasks.ts
+++ b/src/commands/scaffolding/scaffoldTyeTasks.ts
@@ -73,7 +73,6 @@ export async function scaffoldTyeTasks(context: IActionContext, configurationPro
         workspaceConfiguration.folder,
         label => {
             const tyeRunTask: TyeRunTaskDefinition = {
-                applicationName: configuration.name,
                 label,
                 type: 'tye-run',
                 watch: true

--- a/src/debug/tyeDebugConfigurationProvider.ts
+++ b/src/debug/tyeDebugConfigurationProvider.ts
@@ -59,7 +59,7 @@ export class TyeDebugConfigurationProvider implements vscode.DebugConfigurationP
                         this.tyeApplicationProvider
                             .applications
                             .pipe(
-                                map(applications => applications.find(a => a.name === tyeDebugConfiguration.applicationName)),
+                                map(applications => applications.find(a => a.name.toLowerCase() === tyeDebugConfiguration.applicationName.toLowerCase())),
                                 filter(isValidApplication),
                                 filter(allServicesRunning),
                                 first(),

--- a/src/tasks/tyeRunTaskProvider.ts
+++ b/src/tasks/tyeRunTaskProvider.ts
@@ -17,7 +17,6 @@ export type TyeDistributedTraceProvider = 'zipkin';
 export type TyeVerbosity = 'Debug' | 'Info' | 'Quiet';
 
 export interface TyeRunTaskDefinition extends TaskDefinition {
-    applicationName: string; // TODO: Infer this from output and/or the dashboard API.
     build?: boolean;
     dashboard?: boolean;
     debug?: '*' | string | string[];


### PR DESCRIPTION
Resolves an issue in cases where the user edits the `applicationName` of the `tye` launch configuration such that the case no longer matches that in `tye.yaml`, which prevents the extension from identifying and attaching to application services.  The change is to make such matching case-insensitive.

Also removes scaffolding and references to the `applicationName` property of the `tye-run` task, as it is no longer used by the extension.  (Now only the `tye` launch configuration will have that property.)

Resolves #167.