### PR TITLE
Override use of deprecated netstat on Linux.

### DIFF
--- a/src/services/portProvider.ts
+++ b/src/services/portProvider.ts
@@ -33,7 +33,7 @@ function lsofCommandParser(line: string, callback: (item: netstat.ParsedItem) =>
     };
 
     return callback(netstat.utils.normalizeValues(item));
-};
+}
 
 
 // NOTE: The TS definition incorrectly asserts that `darwin` and `linux` are const.

--- a/src/services/portProvider.ts
+++ b/src/services/portProvider.ts
@@ -3,14 +3,15 @@
 
 import * as netstat from 'node-netstat';
 
-netstat.commands.darwin = {
+const lsofCommand = {
     cmd: 'lsof',
     args: ['-Pn', '-i4', '-sTCP:LISTEN']
 };
 
-// NOTE: The TS definition incorrectly asserts that `darwin` is const.
-// TODO: Update the TS definitions.
-(netstat.parsers.darwin as unknown) = (line: string, callback: (item: netstat.ParsedItem) => void) => {
+netstat.commands.darwin = lsofCommand;
+netstat.commands.linux = lsofCommand;
+
+function lsofCommandParser(line: string, callback: (item: netstat.ParsedItem) => void): void {
     const parts = line.split(/\s/).filter(String);
     if (!parts.length || (parts.length !== 9 && parts.length !== 10 )) {
         // We expect 9 or 10 columns of data; bail when not found...
@@ -33,6 +34,12 @@ netstat.commands.darwin = {
 
     return callback(netstat.utils.normalizeValues(item));
 };
+
+
+// NOTE: The TS definition incorrectly asserts that `darwin` and `linux` are const.
+// TODO: Update the TS definitions.
+(netstat.parsers.darwin as unknown) = lsofCommandParser;
+(netstat.parsers.linux as unknown) = lsofCommandParser;
 
 function netstatAsync(options: Omit<netstat.Options, 'done'>): Promise<netstat.ParsedItem[]> {
     return new Promise(


### PR DESCRIPTION
So it looks like `netstat` is no longer installed by default on certain Linux distros (e.g. Ubuntu).  This change moves to `lsof` instead (like on Mac).

> Given we're now effectively overriding `node-netstat`s handling on 2 out of 3 platforms (i.e. Mac and Linux), we should consider just handling the `lsof` ourselves and not be reliant on `node-netstat` at all.  However, that's more of an extensive change that would have to wait.

Resolves #179.