### PR TITLE
Switch to `@vscode/test-electron`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-tye",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-tye",
-			"version": "0.5.0",
+			"version": "0.5.1",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@microsoft/vscode-azext-utils": "^0.3.7",
@@ -31,6 +31,7 @@
 				"@types/vscode": "^1.67.0",
 				"@typescript-eslint/eslint-plugin": "^5.27.0",
 				"@typescript-eslint/parser": "^5.27.0",
+				"@vscode/test-electron": "^2.2.0",
 				"eslint": "^8.16.0",
 				"glob": "^8.0.3",
 				"mocha": "^10.0.0",
@@ -40,7 +41,6 @@
 				"typescript": "^4.7.2",
 				"vsce": "^2.9.1",
 				"vscode-nls-dev": "^4.0.0",
-				"vscode-test": "^1.6.1",
 				"webpack": "^5.73.0",
 				"webpack-cli": "^4.9.2"
 			},
@@ -594,6 +594,21 @@
 				"vscode": "^1.60.0"
 			}
 		},
+		"node_modules/@vscode/test-electron": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.2.0.tgz",
+			"integrity": "sha512-xk2xrOTMG75/hxO8OVVZ+GErv9gmdZwOD8rEHV3ty3n1Joav2yFcfrmqD6Ukref27U13LEL8gVvSHzauGAK5nQ==",
+			"dev": true,
+			"dependencies": {
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "^5.0.0",
+				"rimraf": "^3.0.2",
+				"unzipper": "^0.10.11"
+			},
+			"engines": {
+				"node": ">=8.9.3"
+			}
+		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -1033,7 +1048,7 @@
 		"node_modules/binary": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+			"integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
 			"dev": true,
 			"dependencies": {
 				"buffers": "~0.1.1",
@@ -1080,7 +1095,7 @@
 		"node_modules/bluebird": {
 			"version": "3.4.7",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
 			"dev": true
 		},
 		"node_modules/boolbase": {
@@ -1197,7 +1212,7 @@
 		"node_modules/buffers": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.2.0"
@@ -1256,7 +1271,7 @@
 		"node_modules/chainsaw": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+			"integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
 			"dev": true,
 			"dependencies": {
 				"traverse": ">=0.3.0 <0.4"
@@ -1750,7 +1765,7 @@
 		"node_modules/duplexer2": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
 			"dev": true,
 			"dependencies": {
 				"readable-stream": "^2.0.2"
@@ -2665,9 +2680,9 @@
 			}
 		},
 		"node_modules/https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"dev": true,
 			"dependencies": {
 				"agent-base": "6",
@@ -3074,7 +3089,7 @@
 		"node_modules/listenercount": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+			"integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
 			"dev": true
 		},
 		"node_modules/loader-runner": {
@@ -4382,7 +4397,7 @@
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
 			"dev": true
 		},
 		"node_modules/shallow-clone": {
@@ -4791,7 +4806,7 @@
 		"node_modules/traverse": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+			"integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -5264,22 +5279,6 @@
 			},
 			"engines": {
 				"vscode": "^1.19.1"
-			}
-		},
-		"node_modules/vscode-test": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-			"deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
-			"dev": true,
-			"dependencies": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			},
-			"engines": {
-				"node": ">=8.9.3"
 			}
 		},
 		"node_modules/watchpack": {
@@ -6034,6 +6033,18 @@
 				"@microsoft/1ds-post-js": "^3.2.3"
 			}
 		},
+		"@vscode/test-electron": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.2.0.tgz",
+			"integrity": "sha512-xk2xrOTMG75/hxO8OVVZ+GErv9gmdZwOD8rEHV3ty3n1Joav2yFcfrmqD6Ukref27U13LEL8gVvSHzauGAK5nQ==",
+			"dev": true,
+			"requires": {
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "^5.0.0",
+				"rimraf": "^3.0.2",
+				"unzipper": "^0.10.11"
+			}
+		},
 		"@webassemblyjs/ast": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -6398,7 +6409,7 @@
 		"binary": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+			"integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
 			"dev": true,
 			"requires": {
 				"buffers": "~0.1.1",
@@ -6438,7 +6449,7 @@
 		"bluebird": {
 			"version": "3.4.7",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
 			"dev": true
 		},
 		"boolbase": {
@@ -6516,7 +6527,7 @@
 		"buffers": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
 			"dev": true
 		},
 		"call-bind": {
@@ -6550,7 +6561,7 @@
 		"chainsaw": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+			"integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
 			"dev": true,
 			"requires": {
 				"traverse": ">=0.3.0 <0.4"
@@ -6919,7 +6930,7 @@
 		"duplexer2": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
 			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.2"
@@ -7619,9 +7630,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"dev": true,
 			"requires": {
 				"agent-base": "6",
@@ -7907,7 +7918,7 @@
 		"listenercount": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+			"integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
 			"dev": true
 		},
 		"loader-runner": {
@@ -8883,7 +8894,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
 			"dev": true
 		},
 		"shallow-clone": {
@@ -9179,7 +9190,7 @@
 		"traverse": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+			"integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
 			"dev": true
 		},
 		"ts-loader": {
@@ -9541,18 +9552,6 @@
 			"integrity": "sha512-SlEPDi+0gwxor4ANzBtXwqROPQdQkClHeVJgnkvdDF5Xnl407htCsabTPAq4Di8muObORtLchqQS/k1ocaGDEg==",
 			"requires": {
 				"tas-client": "0.1.45"
-			}
-		},
-		"vscode-test": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-			"dev": true,
-			"requires": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
 			}
 		},
 		"watchpack": {

--- a/package.json
+++ b/package.json
@@ -402,6 +402,7 @@
 		"@types/vscode": "^1.67.0",
 		"@typescript-eslint/eslint-plugin": "^5.27.0",
 		"@typescript-eslint/parser": "^5.27.0",
+		"@vscode/test-electron": "^2.2.0",
 		"eslint": "^8.16.0",
 		"glob": "^8.0.3",
 		"mocha": "^10.0.0",
@@ -411,7 +412,6 @@
 		"typescript": "^4.7.2",
 		"vsce": "^2.9.1",
 		"vscode-nls-dev": "^4.0.0",
-		"vscode-test": "^1.6.1",
 		"webpack": "^5.73.0",
 		"webpack-cli": "^4.9.2"
 	},

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 
-import { runTests } from 'vscode-test';
+import { runTests } from '@vscode/test-electron';
 
 async function main() {
 	try {


### PR DESCRIPTION
CodeQL flagged some stuff in `vscode-test`, notwithstanding the fact that it's external and has nothing to do with this. The simplest fix is to just use `@vscode/test-electron`. That will also help with the frequent test failures on Mac.